### PR TITLE
scroll fix

### DIFF
--- a/src/hooks/useWindowDimensions.ts
+++ b/src/hooks/useWindowDimensions.ts
@@ -1,26 +1,23 @@
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 
 export interface WindowDimensions {
   height: number;
   width: number;
 }
+const hasWindow = typeof window !== "undefined";
 
+function getWindowDimensions() {
+  const width = hasWindow ? window.innerWidth : null;
+  const height = hasWindow ? window.innerHeight : null;
+  return {
+    height,
+    width,
+  } as WindowDimensions;
+}
 export default function useWindowDimensions(): WindowDimensions | undefined {
-  const [windowDimensions, setWindowDimensions] = useState<WindowDimensions | undefined>();
-
-  useEffect(
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+  useLayoutEffect(
     () => {
-      const hasWindow = typeof window !== "undefined";
-
-      function getWindowDimensions() {
-        const width = hasWindow ? window.innerWidth : null;
-        const height = hasWindow ? window.innerHeight : null;
-        return {
-          height,
-          width,
-        } as WindowDimensions;
-      }
-
       function handleResize() {
         setWindowDimensions(getWindowDimensions());
       }


### PR DESCRIPTION
The issue was that you never defined the state for the window dimensions in the hook. Like the function to get the window dimensions never ran until someone triggered the hook with a resize. All I did was run the getWindowDimensions function when we call the use state function. Im pretty sure everything is solid and fixed but you might want to check on the typescript types to make sure I didn't mess anything up.