### PR TITLE
Add song overview list view henry quillin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "cloudinary-react": "^1.7.1",
         "formik": "^2.2.9",
         "material-ui-image": "^3.3.2",
+        "moment": "^2.29.1",
+        "moment-duration-format": "^2.3.2",
         "mui-image": "^1.0.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -12362,6 +12364,19 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-duration-format": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -28737,6 +28752,16 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-duration-format": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "cloudinary-react": "^1.7.1",
     "formik": "^2.2.9",
     "material-ui-image": "^3.3.2",
+    "moment": "^2.29.1",
+    "moment-duration-format": "^2.3.2",
     "mui-image": "^1.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,13 +44,7 @@ const App = () => {
               <Redirect exact from="/home" to="/home/songs" />
               <Route
                 path="/home/:page?"
-                render={ ({ match, history, ...otherProps }) => (
-                  <Home
-                    page={ match.params.page }
-                    history={ history }
-                    { ...otherProps }
-                  />
-                ) }
+                render={ ({ match, ...otherProps }) => <Home page={ match.params.page } { ...otherProps } /> }
               />
             </Switch>
           </BrowserRouter>

--- a/src/components/TableLine.tsx
+++ b/src/components/TableLine.tsx
@@ -3,7 +3,7 @@
  */
 
 import { FunctionComponent } from "react";
-import HorizontalLine from "./styled/HorizontalLine";
+import StyledAnimatedGradientLine from "./styled/AnimatedGradientLine";
 
 interface TableLineProps {
   columns: number;
@@ -13,7 +13,7 @@ const TableLine: FunctionComponent<TableLineProps> = ({ columns }) => {
   return (
     <tr>
       <td colSpan={ columns } style={ { paddingBottom: "16px" } }>
-        <HorizontalLine />
+        <StyledAnimatedGradientLine height="2px" animationSpeed="20s" />
       </td>
     </tr>
   );

--- a/src/components/TableLine.tsx
+++ b/src/components/TableLine.tsx
@@ -13,7 +13,7 @@ const TableLine: FunctionComponent<TableLineProps> = ({ columns }) => {
   return (
     <tr>
       <td colSpan={ columns } style={ { paddingBottom: "16px" } }>
-        <StyledAnimatedGradientLine height="2px" animationSpeed="20s" />
+        <StyledAnimatedGradientLine height="2px" />
       </td>
     </tr>
   );

--- a/src/components/TableLine.tsx
+++ b/src/components/TableLine.tsx
@@ -3,7 +3,7 @@
  */
 
 import { FunctionComponent } from "react";
-import StyledAnimatedGradientLine from "./styled/AnimatedGradientLine";
+import HorizontalLine from "./styled/HorizontalLine";
 
 interface TableLineProps {
   columns: number;
@@ -13,7 +13,7 @@ const TableLine: FunctionComponent<TableLineProps> = ({ columns }) => {
   return (
     <tr>
       <td colSpan={ columns } style={ { paddingBottom: "16px" } }>
-        <StyledAnimatedGradientLine height="2px" />
+        <HorizontalLine />
       </td>
     </tr>
   );

--- a/src/components/styled/AnimatedGradientLine.ts
+++ b/src/components/styled/AnimatedGradientLine.ts
@@ -14,7 +14,7 @@ const AnimatedGradient = keyframes`
 `;
 
 const StyledAnimatedGradientLine = styled("hr")(
-  ({ height = "3px", animationSpeed = "40s" }: AnimatedGradientLineProps) => ({
+  ({ height = "2px", animationSpeed = "40s" }: AnimatedGradientLineProps) => ({
     animation: `${AnimatedGradient} ${animationSpeed} ease infinite;`,
     background: `linear-gradient(270deg, ${theme.custom.gradientStart}, ${theme.custom.gradientEnd});`,
     backgroundSize: "400% 400%;",

--- a/src/components/styled/AnimatedGradientLine.ts
+++ b/src/components/styled/AnimatedGradientLine.ts
@@ -2,18 +2,25 @@ import { styled } from "@mui/material/styles";
 import { keyframes } from "@mui/system";
 import theme from "theme";
 
+interface AnimatedGradientLineProps {
+  height?: string;
+  animationSpeed?: string;
+}
+
 const AnimatedGradient = keyframes`
     0%{background-position:0% 50%}
     50%{background-position:100% 50%}
     100%{background-position:0% 50%}
 `;
 
-const AnimatedGradientLine = styled("hr")({
-  animation: `${AnimatedGradient} 10s ease infinite;`,
-  background: `linear-gradient(270deg, ${theme.custom.gradientStart}, ${theme.custom.gradientEnd});`,
-  backgroundSize: "400% 400%;",
-  border: "none",
-  height: "3px",
-});
+const StyledAnimatedGradientLine = styled("hr")(
+  ({ height = "3px", animationSpeed = "15s" }: AnimatedGradientLineProps) => ({
+    animation: `${AnimatedGradient} ${animationSpeed} ease infinite;`,
+    background: `linear-gradient(270deg, ${theme.custom.gradientStart}, ${theme.custom.gradientEnd});`,
+    backgroundSize: "400% 400%;",
+    border: "none",
+    height: `${height}`,
+  })
+);
 
-export default AnimatedGradientLine;
+export default StyledAnimatedGradientLine;

--- a/src/components/styled/AnimatedGradientLine.ts
+++ b/src/components/styled/AnimatedGradientLine.ts
@@ -14,7 +14,7 @@ const AnimatedGradient = keyframes`
 `;
 
 const StyledAnimatedGradientLine = styled("hr")(
-  ({ height = "3px", animationSpeed = "15s" }: AnimatedGradientLineProps) => ({
+  ({ height = "3px", animationSpeed = "40s" }: AnimatedGradientLineProps) => ({
     animation: `${AnimatedGradient} ${animationSpeed} ease infinite;`,
     background: `linear-gradient(270deg, ${theme.custom.gradientStart}, ${theme.custom.gradientEnd});`,
     backgroundSize: "400% 400%;",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -11,3 +11,5 @@ declare module "*.svg" {
 declare module "cloudinary-react";
 declare module "react-transition-group";
 declare module "styled-components";
+declare module "moment-duration-format";
+declare module "moment";

--- a/src/modules/song/slice.ts
+++ b/src/modules/song/slice.ts
@@ -1,5 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { Role } from "modules/role";
+import moment from "moment";
+import momentDurationFormatSetup from "moment-duration-format";
 import { Song } from "./types";
 
 interface SongState {
@@ -7,6 +9,7 @@ interface SongState {
     [id: number]: Song;
   };
 }
+momentDurationFormatSetup(moment);
 
 const initialState: SongState = {
   // TEMP: Data is mocked until API data is available
@@ -26,6 +29,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(60, "seconds").format(),
       extraInformation: "extra info",
     },
     2: {
@@ -41,6 +45,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "J Cole", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(80, "seconds").format(),
       extraInformation: "extra info",
     },
     3: {
@@ -56,6 +61,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kendrick Lamar", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(90, "seconds").format(),
       extraInformation: "extra info",
     },
     4: {
@@ -71,6 +77,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Tyler the Creator", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(125, "seconds").format(),
       extraInformation: "extra info",
     },
     5: {
@@ -87,6 +94,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(225, "seconds").format(),
       extraInformation: "extra info",
     },
     6: {
@@ -103,6 +111,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(150, "seconds").format(),
       extraInformation: "extra info",
     },
     7: {
@@ -119,6 +128,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(250, "seconds").format(),
       extraInformation: "extra info",
     },
     8: {
@@ -135,6 +145,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(145, "seconds").format(),
       extraInformation: "extra info",
     },
     9: {
@@ -151,6 +162,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(190, "seconds").format(),
       extraInformation: "extra info",
     },
     10: {
@@ -167,6 +179,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(155, "seconds").format(),
       extraInformation: "extra info",
     },
     11: {
@@ -183,6 +196,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(245, "seconds").format(),
       extraInformation: "extra info",
     },
     12: {
@@ -199,6 +213,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(245, "seconds").format(),
       extraInformation: "extra info",
     },
     13: {
@@ -215,6 +230,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(245, "seconds").format(),
       extraInformation: "extra info",
     },
     14: {
@@ -231,6 +247,7 @@ const initialState: SongState = {
         2: { name: "Dan", role: Role.SoundEngineer, stake: 0.25 },
         3: { name: "Kid Cudi", role: Role.Singer, stake: 0.5 },
       },
+      duration: moment.duration(245, "seconds").format(),
       extraInformation: "extra info",
     },
   },

--- a/src/modules/song/types.ts
+++ b/src/modules/song/types.ts
@@ -23,5 +23,6 @@ export interface Song {
   contributors: {
     [id: number]: Contributor;
   };
+  duration: string;
   extraInformation: string;
 }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,27 +1,29 @@
 import { Box, Container, Tabs } from "@mui/material";
 import { Page, useWindowDimensions } from "common";
 import { Tab } from "components";
-import { History } from "history";
 import React, { FunctionComponent, HTMLAttributes } from "react";
+import { useHistory } from "react-router-dom";
 import Playlists from "./playlists";
 import Songs from "./songs";
 import TabPanel from "./TabPanel";
 import WalletOverview from "./wallet";
 
+
 interface HomePropTypes extends HTMLAttributes<HTMLDivElement> {
   page?: string;
-  history: History;
 }
 
 const Home: FunctionComponent<HomePropTypes> = (props) => {
   const windowDimensions = useWindowDimensions();
   const height = windowDimensions && windowDimensions.height;
 
-  const { page: pageName, history } = props;
+  const { page: pageName } = props;
 
   const initialPage = (pageName && Page[pageName as keyof typeof Page]) || Page.songs;
 
   const [value, setValue] = React.useState(initialPage);
+
+  const history = useHistory();
 
   const handleChange = (_event: React.SyntheticEvent, newValue: Page) => {
     history?.push(`/home/${Page[newValue]}`);
@@ -62,7 +64,7 @@ const Home: FunctionComponent<HomePropTypes> = (props) => {
       >
         <TabPanel value={ value } page={ Page.songs }>
           <Container maxWidth="lg">
-            <Songs history={ history } />
+            <Songs />
           </Container>
         </TabPanel>
         <TabPanel value={ value } page={ Page.playlists }>

--- a/src/pages/home/songs/Song.tsx
+++ b/src/pages/home/songs/Song.tsx
@@ -1,7 +1,7 @@
 import { Box, CardMedia } from "@mui/material";
 import { SquareGridCard } from "components";
-import { History } from "history";
 import { useState } from "react";
+import { useHistory } from "react-router-dom";
 import { Transition } from "react-transition-group";
 import SongHover from "./SongHover";
 
@@ -9,11 +9,11 @@ interface SongProps {
   songId: number;
   name: string;
   albumImage: string;
-  history: History;
 }
 
-const Song = ({ songId, name, albumImage, history }: SongProps) => {
+const Song = ({ songId, name, albumImage }: SongProps) => {
   const [hovering, setHover] = useState(false);
+  const history = useHistory();
 
   return (
     <SquareGridCard onClick={ () => history.push(`/home/song/${songId}`) }>

--- a/src/pages/home/songs/SongGrid.tsx
+++ b/src/pages/home/songs/SongGrid.tsx
@@ -1,19 +1,20 @@
 import { Grid } from "@mui/material";
 import addSong from "assets/images/add-song.png";
 import { useAppSelector } from "common";
-import { History } from "history";
 import { selectSongs } from "modules/song";
 import { Dispatch, SetStateAction } from "react";
+import { useHistory } from "react-router-dom";
 import AddSongCard from "./AddSongCard";
 import Song from "./Song";
 
+
 export interface SongGridProps {
-  history: History;
   setOpenPopup: Dispatch<SetStateAction<boolean>>;
 }
 
-const SongGrid = ({ history, setOpenPopup }: SongGridProps) => {
+const SongGrid = ({ setOpenPopup }: SongGridProps) => {
   const songs = useAppSelector(selectSongs);
+  const history = useHistory();
 
   return (
     <>
@@ -34,7 +35,6 @@ const SongGrid = ({ history, setOpenPopup }: SongGridProps) => {
                 sx={ { margin: "0px" } }
               >
                 <Song
-                  history={ history }
                   songId={ songId }
                   name={ name }
                   albumImage={ albumImage }

--- a/src/pages/home/songs/SongList.tsx
+++ b/src/pages/home/songs/SongList.tsx
@@ -1,0 +1,53 @@
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import MuiTableRow from "@mui/material/TableRow";
+import { useAppSelector } from "common";
+import { TableCell, TableCellImage, TableHeadCell, TableLine, TableRow } from "components";
+import { selectSongs } from "modules/song";
+import { FunctionComponent } from "react";
+import { useHistory } from "react-router-dom";
+
+const SongList: FunctionComponent = () => {
+  const history = useHistory();
+
+  const songs = useAppSelector(selectSongs);
+
+  return (
+    <TableContainer>
+      <Table>
+        <colgroup>
+          <col style={ { width: "5%" } } />
+        </colgroup>
+
+        <TableHead>
+          <MuiTableRow>
+            <TableHeadCell />
+            <TableHeadCell>Title</TableHeadCell>
+            <TableHeadCell>Role</TableHeadCell>
+            <TableHeadCell>Genre</TableHeadCell>
+            <TableHeadCell>Duration</TableHeadCell>
+          </MuiTableRow>
+          <TableLine columns={ 5 } />
+        </TableHead>
+
+        <TableBody>
+          { Object.values(songs).map(({ id, name, userRole, genre, albumImage, duration }) => (
+            <TableRow key={ id } onClick={ () => history.push(`/home/song/${id}`) }>
+              <TableCell>
+                <TableCellImage alt={ name } src={ albumImage } />
+              </TableCell>
+              <TableCell>{ name }</TableCell>
+              <TableCell>{ userRole }</TableCell>
+              <TableCell>{ genre }</TableCell>
+              <TableCell sx={ { paddingLeft: "25px" } }>{ duration }m</TableCell>
+            </TableRow>
+          )) }
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default SongList;

--- a/src/pages/home/songs/Songs.tsx
+++ b/src/pages/home/songs/Songs.tsx
@@ -1,18 +1,24 @@
 import { Box } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useAppSelector } from "common";
 import Popup from "components/Popup";
 import { History } from "history";
 import { selectSongs } from "modules/song";
 import { useState } from "react";
+import theme from "theme";
 import PartyStarter from "./PartyStarter";
 import SongGrid from "./SongGrid";
+import SongList from "./SongList";
 import SongUploadForm from "./SongUploadForm";
+
 
 export interface SongsProps {
   history: History;
 }
 
 const Songs = ({ history }: SongsProps) => {
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+
   const songs = useAppSelector(selectSongs);
 
   const [openPopup, setOpenPopup] = useState(false);
@@ -32,10 +38,11 @@ const Songs = ({ history }: SongsProps) => {
       </Popup>
 
       <Box pb={ 2 }>
-        <SongGrid
+        {/* <SongGrid
           history= { history }
           setOpenPopup={ setOpenPopup }
-        />
+        /> */}
+        <SongList />
       </Box>
     </>
   );

--- a/src/pages/home/songs/Songs.tsx
+++ b/src/pages/home/songs/Songs.tsx
@@ -2,7 +2,6 @@ import { Box } from "@mui/material";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useAppSelector } from "common";
 import Popup from "components/Popup";
-import { History } from "history";
 import { selectSongs } from "modules/song";
 import { useState } from "react";
 import theme from "theme";
@@ -11,11 +10,7 @@ import SongGrid from "./SongGrid";
 import SongList from "./SongList";
 import SongUploadForm from "./SongUploadForm";
 
-export interface SongsProps {
-  history: History;
-}
-
-const Songs = ({ history }: SongsProps) => {
+const Songs = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
 
   const songs = useAppSelector(selectSongs);
@@ -32,7 +27,7 @@ const Songs = ({ history }: SongsProps) => {
         <SongUploadForm setOpenPopup={ setOpenPopup } />
       </Popup>
 
-      <Box pb={ 2 }>{ isSmallScreen ? <SongList /> : <SongGrid history={ history } setOpenPopup={ setOpenPopup } /> }</Box>
+      <Box pb={ 2 }>{ isSmallScreen ? <SongList /> : <SongGrid setOpenPopup={ setOpenPopup } /> }</Box>
     </>
   );
 };

--- a/src/pages/home/songs/Songs.tsx
+++ b/src/pages/home/songs/Songs.tsx
@@ -11,7 +11,6 @@ import SongGrid from "./SongGrid";
 import SongList from "./SongList";
 import SongUploadForm from "./SongUploadForm";
 
-
 export interface SongsProps {
   history: History;
 }
@@ -29,21 +28,11 @@ const Songs = ({ history }: SongsProps) => {
 
   return (
     <>
-      <Popup
-        height="522px"
-        openPopup={ openPopup }
-        setOpenPopup={ setOpenPopup }
-      >
+      <Popup height="522px" openPopup={ openPopup } setOpenPopup={ setOpenPopup }>
         <SongUploadForm setOpenPopup={ setOpenPopup } />
       </Popup>
 
-      <Box pb={ 2 }>
-        {/* <SongGrid
-          history= { history }
-          setOpenPopup={ setOpenPopup }
-        /> */}
-        <SongList />
-      </Box>
+      <Box pb={ 2 }>{ isSmallScreen ? <SongList /> : <SongGrid history={ history } setOpenPopup={ setOpenPopup } /> }</Box>
     </>
   );
 };

--- a/src/pages/home/songs/__tests__/Song.test.tsx
+++ b/src/pages/home/songs/__tests__/Song.test.tsx
@@ -3,23 +3,38 @@ import { createMemoryHistory } from "history";
 import Song from "../Song";
 const history = createMemoryHistory();
 
-describe("<Song />", () => {
-  test("Hover Effect Works", async () => {
-    const songId = 1;
-    const name = "string";
-    const album_image = "https://upload.wikimedia.org/wikipedia/en/0/0a/Kidcudimanonthemoonthelegendof.jpg";
-    const song = (
-      <Song
-        history={ history }
-        songId={ songId }
-        name={ name }
-        albumImage={ album_image }
-      />
-    );
+const mockPush = jest.fn();
 
+jest.mock("react-router-dom", () => ({
+  useHistory: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("<Song />", () => {
+  const songId = 1;
+  const name = "string";
+  const album_image = "https://upload.wikimedia.org/wikipedia/en/0/0a/Kidcudimanonthemoonthelegendof.jpg";
+  const song = <Song history={ history } songId={ songId } name={ name } albumImage={ album_image } />;
+
+  it("renders the song content", () => {
+    const { queryByRole } = render(song);
+
+    expect(queryByRole("img")).toBeTruthy();
+  });
+
+  it("Hover Effect Works", async () => {
     render(song);
     fireEvent.mouseOver(screen.getByText(name));
     await waitFor(() => screen.findByText(name));
     expect(screen.getByText(name)).toBeDefined();
   });
-})
+
+  test("clicking the song calls history.push() with song ID", () => {
+    const { getByRole, getByTestId } = render(song);
+
+    const media = getByRole("img");
+    fireEvent.click(media);
+    expect(mockPush).toHaveBeenCalledWith("/home/song/1");
+  });
+});

--- a/src/pages/home/songs/__tests__/Song.test.tsx
+++ b/src/pages/home/songs/__tests__/Song.test.tsx
@@ -15,7 +15,7 @@ describe("<Song />", () => {
   const songId = 1;
   const name = "string";
   const album_image = "https://upload.wikimedia.org/wikipedia/en/0/0a/Kidcudimanonthemoonthelegendof.jpg";
-  const song = <Song history={ history } songId={ songId } name={ name } albumImage={ album_image } />;
+  const song = <Song songId={ songId } name={ name } albumImage={ album_image } />;
 
   it("renders the song content", () => {
     const { queryByRole } = render(song);

--- a/src/pages/home/songs/__tests__/SongList.test.tsx
+++ b/src/pages/home/songs/__tests__/SongList.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render } from "@testing-library/react";
+import { Role } from "modules/role";
+import moment from "moment";
+import momentDurationFormatSetup from "moment-duration-format";
+import { Provider } from "react-redux";
+import store from "store";
+import SongList from "../SongList";
+
+const mockPush = jest.fn();
+momentDurationFormatSetup(moment);
+const mockMoment = moment;
+const mockRole = Role;
+
+/**
+ *  Mocks
+ */
+
+jest.mock("react-router-dom", () => ({
+  useHistory: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock("modules/song", () => ({
+  selectSongs: () => ({
+    1: {
+      name: "Mr Rager",
+      id: 1,
+      genre: "Hip Hop",
+      userRole: mockRole.Singer,
+      releaseDate: new Date(2016, 5).toString(),
+      description: "Kid Cudi's best",
+      albumImage: "https://upload.wikimedia.org/wikipedia/en/0/0a/Kidcudimanonthemoonthelegendof.jpg",
+      contributors: {
+        1: { name: "John", role: mockRole.Producer, stake: 0.25 },
+        2: { name: "Dan", role: mockRole.SoundEngineer, stake: 0.25 },
+        3: { name: "Cudi", role: mockRole.Singer, stake: 0.5 },
+      },
+      duration: mockMoment.duration(60, "seconds").format(),
+      extraInformation: "extra info",
+    },
+  }),
+}));
+
+const mockSongList = (
+  <Provider store={ store }>
+    <SongList />
+  </Provider>
+);
+
+/**
+ * Tests
+ */
+
+describe("<SongList />", () => {
+  it("renders the song content", () => {
+    const { queryByText } = render(mockSongList);
+
+    expect(queryByText("Mr Rager")).toBeTruthy();
+    expect(queryByText("Singer")).toBeTruthy();
+    expect(queryByText("Hip Hop")).toBeTruthy();
+    expect(queryByText("1:00m")).toBeTruthy();
+  });
+
+  test("clicking the song calls history.push() with song ID", () => {
+    const { getByRole, getByText } = render(mockSongList);
+
+    const media = getByRole("img");
+    const title = getByText("Mr Rager");
+    const count = getByText("1:00m");
+
+    [media, title, count].forEach(element => {
+      fireEvent.click(element);
+      expect(mockPush).toHaveBeenCalledWith("/home/song/1");
+    });
+  });
+});


### PR DESCRIPTION
## What

- Adds song list view on small screens

### Also

- Adds subtle animation to the gradient line above the list view 
- Removes unnecessary prop drilling for history. Adds the useHistory() hook to the components instead. 

## Test

1. Decrease your screen size to less than 900 pixels in width
2. Confirm that playlists are displayed in a list
3. Confirm that clicking appends the songId to history