### PR TITLE
Fixes issue where Google profile image was not fetched successfully

### DIFF
--- a/src/pages/home/SideBar.tsx
+++ b/src/pages/home/SideBar.tsx
@@ -57,7 +57,11 @@ export const SideBar: FunctionComponent<SideBarProps> = (
       <Box display="flex" flexDirection="column" alignItems="center">
         <Stack mt={ 3.5 } spacing={ 2 }>
           { !!profile.pictureUrl && (
-            <ProfileImage src={ profile.pictureUrl } aria-label="profile image" />
+            <ProfileImage
+              src={ profile.pictureUrl }
+              aria-label="profile image"
+              referrerPolicy="no-referrer"
+            />
           ) }
 
           <Typography variant="h4" fontWeight={ 700 } align="center">

--- a/src/pages/home/profile/Profile.tsx
+++ b/src/pages/home/profile/Profile.tsx
@@ -102,6 +102,7 @@ const Profile: FunctionComponent = () => {
           alt="Profile picture"
           src={ pictureUrl }
           sx={ { marginBottom: 5 } }
+          referrerPolicy="no-referrer"
         />
       ) }
       <Formik


### PR DESCRIPTION
- Implements a fix recommended in [this article](https://stackoverflow.com/questions/40570117/http403-forbidden-error-when-trying-to-load-img-src-with-google-profile-pic) to enable the Google profile image to load successfully: