### PR TITLE
Re-fetch songs every minute until encoding complete

### DIFF
--- a/src/pages/home/library/SongList.tsx
+++ b/src/pages/home/library/SongList.tsx
@@ -64,16 +64,33 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
       remainingSongsOnLastPage > 0 ? remainingSongsOnLastPage : rowsPerPage;
   }
 
+  const [streamUrlMissing, setStreamUrlMissing] = useState(true);
+
   const {
     data: songData = [],
     isLoading,
     isSuccess,
-  } = useGetSongsQuery({
-    ownerIds: ["me"],
-    offset: page - 1,
-    limit: songsToRequest,
-    phrase: query,
-  });
+  } = useGetSongsQuery(
+    {
+      ownerIds: ["me"],
+      offset: page - 1,
+      limit: songsToRequest,
+      phrase: query,
+    },
+    {
+      // Polls for new songs every minute if the streamUrl is missing
+      pollingInterval: streamUrlMissing ? 60000 : undefined,
+    }
+  );
+
+  // Checks if any of the songs are missing a streamUrl
+  useEffect(() => {
+    if (songData.some((song) => !song.streamUrl)) {
+      setStreamUrlMissing(true);
+    } else {
+      setStreamUrlMissing(false);
+    }
+  }, [songData, streamUrlMissing]);
 
   const hlsJsParams = useMemo(
     () => ({


### PR DESCRIPTION
Refetches songs in the background every minute until the audio for all songs have been succesfully encoded. The fetch occurs in the background and does not trigger the loading animation for the list.