### PR TITLE
Allows thunk response to be accessed from asThunkHook util result

### DIFF
--- a/src/common/reduxUtils.ts
+++ b/src/common/reduxUtils.ts
@@ -1,33 +1,49 @@
-import { AsyncThunk } from "@reduxjs/toolkit";
-import { useCallback, useState } from "react";
+import { AsyncThunk, AsyncThunkAction } from "@reduxjs/toolkit";
+import { useCallback, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
+
+interface UseWrappedThunkResponse<Returned> {
+  readonly isLoading: boolean;
+  readonly data?: Returned;
+}
+
+export interface AsyncThunkActionWithPayload<Returned, Arg>
+  extends AsyncThunkAction<Returned, Arg, Record<string, unknown>> {
+  payload: Returned;
+}
 
 /**
  * Wraps a thunk so that it can be used as a hook that returns
- * a function to call the thunk and a loading status.
+ * a function to call the thunk as well as the loading status
+ * and the thunk return value.
  *
  * @param thunk thunk that should be wrapped with the hook
- * @returns a function that returns the touple: [wrapped thunk, loading status]
+ * @returns a function that returns the touple: [wrapped thunk, { loading, data }]
  */
-export const asThunkHook = <T>(
-  thunk: AsyncThunk<void, T, Record<string, unknown>>
+export const asThunkHook = <Returned, Arg>(
+  thunk: AsyncThunk<Returned, Arg, Record<string, unknown>>
 ) => {
-  const useWrappedThunk = (): readonly [(arg: T) => void, boolean] => {
+  const useWrappedThunk = (): readonly [
+    (arg: Arg) => void,
+    UseWrappedThunkResponse<Returned>
+  ] => {
+    const resultRef = useRef<AsyncThunkActionWithPayload<Returned, Arg>>();
+
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);
 
     const callHook = useCallback(
-      async (arg: T) => {
+      async (arg: Arg) => {
         setIsLoading(true);
-
-        await dispatch(thunk(arg));
-
+        resultRef.current = (await dispatch(
+          thunk(arg)
+        )) as AsyncThunkActionWithPayload<Returned, Arg>;
         setIsLoading(false);
       },
       [dispatch, setIsLoading]
     );
 
-    return [callHook, isLoading];
+    return [callHook, { isLoading, data: resultRef.current?.payload }];
   };
 
   return useWrappedThunk;

--- a/src/pages/home/library/MintSong.tsx
+++ b/src/pages/home/library/MintSong.tsx
@@ -50,8 +50,8 @@ const MintSong = () => {
       role,
     } = emptyProfile,
   } = useGetProfileQuery();
-  const [patchSong, isSongLoading] = usePatchSongThunk();
-  const [generateArtistAgreement, isArtistAgreementLoading] =
+  const [patchSong, { isLoading: isSongLoading }] = usePatchSongThunk();
+  const [generateArtistAgreement, { isLoading: isArtistAgreementLoading }] =
     useGenerateArtistAgreementThunk();
 
   const [stepIndex, setStepIndex] = useState<0 | 1>(0);

--- a/src/pages/home/settings/DeleteAccountDialog.tsx
+++ b/src/pages/home/settings/DeleteAccountDialog.tsx
@@ -19,7 +19,7 @@ const DeleteAccountDialog: FunctionComponent = () => {
 
   const { data: { id } = emptyProfile } = useGetProfileQuery();
 
-  const [deleteAccount, isLoading] = useDeleteAccountThunk();
+  const [deleteAccount, { isLoading }] = useDeleteAccountThunk();
 
   const initialValues = {
     confirmationStatement: "",

--- a/src/pages/home/settings/Settings.tsx
+++ b/src/pages/home/settings/Settings.tsx
@@ -24,7 +24,7 @@ const Settings: FunctionComponent = () => {
   const { data: { oauthType } = emptyProfile } = useGetProfileQuery();
   const isLoginUsernameAndPassword = !oauthType;
 
-  const [changePassword, isLoading] = useChangePasswordThunk();
+  const [changePassword, { isLoading }] = useChangePasswordThunk();
 
   const initialValues: ChangePasswordRequest = {
     currentPassword: "",


### PR DESCRIPTION
Allows the return value from a thunk wrapped in `asThunkHook` to be accessed. E.g.

```
const [callExample, { isLoading, data }] = useCallExampleThunk()

console.log("data: ", data) // will log `undefined` and then the thunk return value after thunk is called

```