### PR TITLE
Hotfix/pagination

### DIFF
--- a/src/pages/home/library/SongList.tsx
+++ b/src/pages/home/library/SongList.tsx
@@ -61,7 +61,7 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
   } = useGetSongsQuery(
     {
       ownerIds: ["me"],
-      offset: page - 1,
+      offset: (page - 1) * rowsPerPage,
       limit: songsToRequest,
       phrase: query,
     },

--- a/src/pages/home/owners/OwnersTable.tsx
+++ b/src/pages/home/owners/OwnersTable.tsx
@@ -50,7 +50,7 @@ export default function OwnersTable({
     isLoading,
     isSuccess,
   } = useGetCollaboratorsQuery({
-    offset: page - 1,
+    offset: (page - 1) * rowsPerPage,
     limit: collaboratorsToRequest,
     phrase: query,
   });


### PR DESCRIPTION
I thought that we needed to update the offset by increments of 1 to get different results, it turns out we need to increment them by the limit. Currently you might see duplicates in different pages for songs and collaborators 