### PR TITLE
fix: remove cookies argument because its set in the headers

### DIFF
--- a/src/modules/song/types.ts
+++ b/src/modules/song/types.ts
@@ -13,7 +13,6 @@ export interface GetSongStreamResponse {
 
 export interface GetSongStreamData {
   readonly url: string;
-  readonly cookies: Record<string, string>;
 }
 
 export interface GetSongsRequest {

--- a/src/pages/home/library/SongList.tsx
+++ b/src/pages/home/library/SongList.tsx
@@ -42,7 +42,6 @@ interface PlayerState {
   readonly isReadyToPlay: boolean;
   readonly song?: Song;
   readonly url?: string;
-  readonly cookies?: Record<string, string>;
 }
 
 export default function SongList({ totalCountOfSongs, query }: SongListProps) {
@@ -156,7 +155,6 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
       setPlayerState((prevState) => ({
         ...prevState,
         url: fetchStreamDataResp.data?.streamData.url,
-        cookies: fetchStreamDataResp.data?.streamData.cookies,
         song: fetchStreamDataResp.data?.song,
         isReadyToPlay: true,
       }));


### PR DESCRIPTION
It turns out the cookies need to be set in the session and hls player will pick them up from there.