### PR TITLE
Hotfix: wait for on submit step before navigation

### DIFF
--- a/src/common/reduxUtils.ts
+++ b/src/common/reduxUtils.ts
@@ -19,7 +19,7 @@ export const asThunkHook = <Returned, Arg>(
   thunk: AsyncThunk<Returned, Arg, Record<string, unknown>>
 ) => {
   const useWrappedThunk = (): readonly [
-    (arg: Arg) => void,
+    (arg: Arg) => Promise<void>,
     UseWrappedThunkResponse<Returned>
   ] => {
     const resultRef = useRef<PayloadAction<Returned>>();

--- a/src/components/form/WizardForm.tsx
+++ b/src/components/form/WizardForm.tsx
@@ -24,7 +24,7 @@ interface FormRoute {
   readonly onSubmitStep?: (
     values: any, // eslint-disable-line
     helpers: FormikHelpers<FormikValues>
-  ) => void;
+  ) => void | Promise<void>;
   /** The route title for the progress stepper */
   readonly progressStepTitle?: string;
 }
@@ -85,7 +85,7 @@ const WizardForm: FunctionComponent<WizardFormProps> = ({
    * Calls `onSubmitStep` if present. If this is the last route, it submits
    * the form, otherwise, it navigates if `navigateOnSubmitStep` is not false.
    */
-  const handleSubmit = (
+  const handleSubmit = async (
     values: FormikValues,
     helpers: FormikHelpers<FormikValues>
   ) => {
@@ -94,11 +94,11 @@ const WizardForm: FunctionComponent<WizardFormProps> = ({
     const shouldNavigate = currentRoute.navigateOnSubmitStep ?? true;
 
     if (currentRoute.onSubmitStep) {
-      currentRoute.onSubmitStep(values, helpers);
+      await currentRoute.onSubmitStep(values, helpers);
     }
 
     if (isLastRoute) {
-      onSubmit(values, helpers);
+      await onSubmit(values, helpers);
       return;
     }
 


### PR DESCRIPTION
Ensures wizard form waits for onSubmitStep to complete before navigating.