### PR TITLE
fix: include credentials when calling the /stream API to store cookies

### DIFF
--- a/src/modules/song/api.ts
+++ b/src/modules/song/api.ts
@@ -86,6 +86,7 @@ export const extendedApi = api.injectEndpoints({
       query: (song) => ({
         url: `v1/songs/${song.id}/stream`,
         method: "GET",
+        credentials: "include",
       }),
       providesTags: [Tags.Song],
 


### PR DESCRIPTION
credentials are required on the /stream API in order for the cookies to be stored in the browser - per https://github.com/reduxjs/redux-toolkit/issues/2095 and confirmed cokkies are stored when local testing.