### PR TITLE
Integration party feedback 7/20/23

### DIFF
--- a/src/common/formUtils.ts
+++ b/src/common/formUtils.ts
@@ -163,6 +163,7 @@ export const commonYupValidation = {
       )
       .min(1, "At least one genre is required")
       .max(5, "Maximum of 5 genres allowed"),
+  moods: Yup.array().max(5, "Maximum of 5 moods allowed"),
   nickname: Yup.string()
     .required("Stage name is required")
     .matches(REGEX_ONLY_ALPHABETS_AND_SPACES, "Please only use letters"),
@@ -214,12 +215,14 @@ export const commonYupValidation = {
       ? new Date(releaseDate)
       : new Date(Date.now() + 11 * 24 * 60 * 60 * 1000);
 
-    return Yup.date().min(
-      minReleaseDate,
-      `Release date must be on or after ${
-        minReleaseDate.toISOString().split("T")[0]
-      }`
-    );
+    return Yup.date()
+      .required("This field is required")
+      .min(
+        minReleaseDate,
+        `Release date must be on or after ${
+          minReleaseDate.toISOString().split("T")[0]
+        }`
+      );
   },
   copyrights: Yup.string().max(
     MAX_CHARACTER_COUNT,

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -13,3 +13,4 @@ export * from "./reduxUtils";
 export * from "./regex";
 export * from "./errors";
 export * from "./types";
+export * from "./miscUtils";

--- a/src/common/miscUtils.ts
+++ b/src/common/miscUtils.ts
@@ -1,0 +1,1 @@
+export const COLLABORATOR_FEE_IN_ADA = 1.3;

--- a/src/components/minting/Owners.tsx
+++ b/src/components/minting/Owners.tsx
@@ -89,25 +89,25 @@ const Owners: FunctionComponent<OwnersProps> = ({
 
             <Stack flexDirection="row" alignItems="center">
               { isEditable ? (
-                <TextInputField
-                  name={ `owners[${idx}].percentage` }
-                  aria-label="Ownership percentage"
-                  max={ 100 }
-                  min={ 0 }
-                  placeholder="%"
-                  type="number"
-                  endAdornment={
-                    <InputAdornment
-                      position="start"
-                      sx={ {
-                        color: theme.colors.white,
-                        mr: 1,
-                      } }
-                    >
-                      <Typography>%</Typography>
-                    </InputAdornment>
-                  }
-                />
+                <Stack maxWidth="108px">
+                  <TextInputField
+                    name={ `owners[${idx}].percentage` }
+                    aria-label="Ownership percentage"
+                    placeholder="%"
+                    type="number"
+                    endAdornment={
+                      <InputAdornment
+                        position="start"
+                        sx={ {
+                          color: theme.colors.white,
+                          mr: 1,
+                        } }
+                      >
+                        <Typography>%</Typography>
+                      </InputAdornment>
+                    }
+                  />
+                </Stack>
               ) : (
                 <Typography>{ owner.percentage }%</Typography>
               ) }

--- a/src/components/minting/SelectCoCreators.tsx
+++ b/src/components/minting/SelectCoCreators.tsx
@@ -6,6 +6,7 @@ import { Formik, FormikProps } from "formik";
 import { Creditor, Featured, Owner } from "modules/song";
 import { FunctionComponent, useEffect, useState } from "react";
 import theme from "theme";
+import { COLLABORATOR_FEE_IN_ADA } from "common";
 import AddOwnerModal from "./AddOwnerModal";
 import FeaturedArtists from "./FeaturedArtists";
 
@@ -152,19 +153,17 @@ const FormContent: FunctionComponent<FormContentProps> = ({
             Add new owner
           </Button>
 
-          <Stack columnGap={ 1 } mt={ 1.5 } flexDirection="row">
-            <Typography variant="subtitle2">
-              For every additional collaborator who will receive royalties, the
-              fee to complete the minting process will increase by 1.5 ADA.
-            </Typography>
+          <Typography variant="subtitle2" mt={ 1.5 } mr={ 2 }>
+            { `For every additional artist who will receive royalties, the
+              fee to complete the minting process will increase by ~₳${COLLABORATOR_FEE_IN_ADA}.` }
             <Tooltip
               title={
-                "This cost is increased with each additional collaborator because " +
+                "This cost is increased with each additional artist because " +
                 "this ADA needs to travel with each portion of stream tokens in order " +
                 "to complete the split, which is an added extra cost for each transaction."
               }
             >
-              <IconButton sx={ { padding: 0 } }>
+              <IconButton sx={ { padding: 0, ml: 0.5 } }>
                 <HelpIcon
                   sx={ {
                     color: theme.colors.grey100,
@@ -174,7 +173,7 @@ const FormContent: FunctionComponent<FormContentProps> = ({
                 />
               </IconButton>
             </Tooltip>
-          </Stack>
+          </Typography>
         </Stack>
       ) }
 

--- a/src/modules/song/api.ts
+++ b/src/modules/song/api.ts
@@ -59,6 +59,7 @@ export const emptySong: Song = {
   iswc: "",
   ipis: [],
   releaseDate: "",
+  publicationDate: "",
 };
 
 export const extendedApi = api.injectEndpoints({

--- a/src/modules/song/types.ts
+++ b/src/modules/song/types.ts
@@ -172,6 +172,7 @@ export interface Song {
   readonly iswc?: string;
   readonly ipis?: ReadonlyArray<string>;
   readonly releaseDate?: string;
+  readonly publicationDate?: string;
   readonly duration?: number;
   readonly streamUrl?: string;
   readonly nftPolicyId?: string;

--- a/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -86,7 +86,10 @@ const BasicSongDetails: FunctionComponent = () => {
     scrollToError(errors, isSubmitting, [
       { error: errors.audio, element: audioRef.current },
       { error: errors.coverArtUrl, element: coverArtUrlRef.current },
-      { error: errors.title || errors.genres, element: songDetailsRef.current },
+      {
+        error: errors.title || errors.genres || errors.moods,
+        element: songDetailsRef.current,
+      },
       {
         error: errors.description,
         element: descriptionRef.current,
@@ -174,8 +177,8 @@ const BasicSongDetails: FunctionComponent = () => {
           <DropdownMultiSelectField
             label="MOOD"
             name="moods"
-            placeholder="Select all that apply"
             options={ moodOptions }
+            placeholder="Select all that apply"
           />
         </Stack>
 

--- a/src/pages/home/uploadSong/UploadSong.tsx
+++ b/src/pages/home/uploadSong/UploadSong.tsx
@@ -154,10 +154,18 @@ const UploadSong: FunctionComponent = () => {
     title: commonYupValidation.title,
     description: commonYupValidation.description,
     genres: commonYupValidation.genres(genreOptions),
+    moods: commonYupValidation.moods,
     owners: Yup.array().when("isMinting", {
       is: (value: boolean) => !!value,
       then: Yup.array()
         .min(1, "At least one owner is required when minting")
+        .test({
+          message: "Owner percentages must be between 00.01% and 100%",
+          test: (owners = []) =>
+            owners.every(
+              ({ percentage = 0 }) => percentage >= 0.01 && percentage <= 100
+            ),
+        })
         .test({
           message: "100% ownership must be distributed",
           test: (owners) => {
@@ -234,6 +242,7 @@ const UploadSong: FunctionComponent = () => {
                 audio: validations.audio,
                 title: validations.title,
                 genres: validations.genres,
+                moods: validations.moods,
                 owners: validations.owners,
                 description: validations.description,
               }),


### PR DESCRIPTION
1. Minting modal in basic steps - Update minting fee text of 1.5 ADA to “~₳1.3”
    a. Any references to ADA or currency in the site should be changed to the format ~₳7.30
2. Minting modal in basic steps - Make tooltip inline with text of “For every additional artist who will receive royalties, the fee to complete the minting process will increase by ~₳1.3"
3. Advanced details - schedule release date field should be a required field
    a. Don’t forget to add a ref and add to the scrollToError method in the correct order
4. On ownership % fields, make sure to add space to cover for 2 decimal fields, example: 10.50 %
    a. Also, add field validation to make sure no more than 2 decimal fields are entered, else mark it as invalid
5. Basic details - Add validation to max 5 Moods, similar to genres