### PR TITLE
CU-85zrymzkd_Settings--Background-color-matches-with-figma-designs-black-ish-not-gray_David-Kirshon

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,34 +30,3 @@
   initial-value: 0deg;
   inherits: false;
 }
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #2c2c2e;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -16,7 +16,7 @@ import theme from "theme";
 import StyledPagination from "./styled/StyledPagination";
 
 const StyledTableCell = styled(TableCell)<TableCellProps>`
-  border-color: ${theme.colors.grey700};
+  border-color: ${theme.colors.black};
   padding: 4px 16px;
 `;
 
@@ -39,7 +39,7 @@ const TablePagination = ({
   lastRowOnPage,
   handlePageChange,
   colSpan,
-  color = theme.colors.grey700,
+  color = theme.colors.black,
   rows = "rows",
   cellStyles,
 }: TablePaginationProps) => {

--- a/src/components/form/FormProgressStepper.tsx
+++ b/src/components/form/FormProgressStepper.tsx
@@ -28,7 +28,7 @@ const statusColor = (activeStep: number, currentIndex: number) => {
 const StepBox = styled(Box)<StepBoxProps>`
   flex-grow: 1;
   color: ${(props) => props.boxColor};
-  background-color: ${theme.colors.black};
+  background-color: ${theme.colors.grey700};
   border-bottom: 3px solid ${(props) => props.boxColor};
   min-height: 60px;
   min-width: 232px;

--- a/src/components/minting/AddOwnerModal.tsx
+++ b/src/components/minting/AddOwnerModal.tsx
@@ -61,11 +61,6 @@ const AddOwnerModal: FunctionComponent<AddOwnerModalProps> = ({
       fullWidth
       onClose={ onClose }
       open={ open }
-      sx={ {
-        "& .MuiPaper-root": {
-          backgroundColor: theme.colors.grey600,
-        },
-      } }
     >
       <Formik
         initialValues={ initialValues }

--- a/src/components/minting/AddOwnerModal.tsx
+++ b/src/components/minting/AddOwnerModal.tsx
@@ -9,7 +9,6 @@ import {
   TextInputField,
 } from "components";
 import { commonYupValidation, useExtractProperty } from "common";
-import theme from "theme";
 import { useGetRolesQuery } from "modules/content";
 import { CollaborationStatus } from "modules/song";
 

--- a/src/components/styled/DashedOutline.ts
+++ b/src/components/styled/DashedOutline.ts
@@ -3,6 +3,7 @@ import { Box } from "@mui/material";
 import theme from "theme";
 
 const DashedOutline = styled(Box)`
+  background-color: ${theme.colors.grey700};
   border-radius: 4px;
   border: 2px dashed ${theme.colors.grey400};
 `;

--- a/src/elements/TextArea.tsx
+++ b/src/elements/TextArea.tsx
@@ -32,7 +32,7 @@ const StyledRootElement = styled.div`
 const StyledTextAreaElement = styled.textarea`
   display: flex;
   flex-grow: 1;
-  background: transparent;
+  background: ${theme.colors.grey600};
   color: white;
   border-width: 0;
   font-family: ${theme.inputField.fontFamily};
@@ -177,7 +177,7 @@ const getBorderColor = (
   isFocused: boolean
 ) => {
   if (isDisabled) {
-    return theme.colors.grey400;
+    return theme.colors.grey500;
   }
 
   if (hasError) {
@@ -188,7 +188,7 @@ const getBorderColor = (
     return theme.colors.white;
   }
 
-  return theme.colors.grey400;
+  return theme.colors.grey500;
 };
 
 export default forwardRef(TextArea);

--- a/src/elements/TextInput.tsx
+++ b/src/elements/TextInput.tsx
@@ -38,7 +38,7 @@ const inputStyles = `
   width: 100%;
   display: flex;
   flex-grow: 1;
-  background: transparent;
+  background: ${theme.colors.grey600};
   color-scheme: dark;
   border-width: 0;
   font-family: ${theme.inputField.fontFamily};

--- a/src/elements/styled/Dialog.ts
+++ b/src/elements/styled/Dialog.ts
@@ -2,9 +2,13 @@ import { Dialog as MuiDialog, styled } from "@mui/material";
 import theme from "theme";
 
 const Dialog = styled(MuiDialog)`
+  & > .MuiBackdrop-root {
+    background-color: ${theme.colors.backdropBlur};
+  }
+
   & .MuiPaper-root {
     border-radius: 8px;
-    background-color: ${theme.colors.grey500};
+    background-color: ${theme.colors.black};
   }
 `;
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,14 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
 
@@ -17,5 +17,4 @@ html,
 #root {
   height: 100%;
   margin: 0;
-  background-color: #0A0A0A;
 }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -24,7 +24,7 @@ const Home: FunctionComponent = () => {
   return (
     <Box
       sx={ {
-        backgroundColor: theme.colors.grey700,
+        backgroundColor: theme.colors.black,
         display: "flex",
         flexGrow: 1,
       } }

--- a/src/pages/home/SideBar.tsx
+++ b/src/pages/home/SideBar.tsx
@@ -30,11 +30,12 @@ export const SideBar: FunctionComponent<SideBarProps> = (
   return (
     <Box
       sx={ {
+        background: theme.colors.black,
+        borderRight: `2px solid ${theme.colors.grey600}`,
         display: "flex",
         height: "100%",
         width: theme.spacing(28.75),
         minWidth: theme.spacing(28.75),
-        background: theme.colors.black,
         flexDirection: "column",
         justifyContent: "space-between",
         padding: 1.25,

--- a/src/pages/home/owners/OwnerModal.tsx
+++ b/src/pages/home/owners/OwnerModal.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent } from "react";
 import { DialogActions, DialogContentText, DialogProps } from "@mui/material";
 import { Button, Dialog, HorizontalLine, Typography } from "elements";
-import theme from "theme";
 
 interface OwnerModalProps extends Omit<DialogProps, "onClose"> {
   readonly onClose: VoidFunction;

--- a/src/pages/home/owners/OwnerModal.tsx
+++ b/src/pages/home/owners/OwnerModal.tsx
@@ -25,7 +25,6 @@ const OwnerModal: FunctionComponent<OwnerModalProps> = ({
       onClose={ onClose }
       sx={ {
         ".MuiDialog-paper": {
-          backgroundColor: theme.colors.black,
           padding: 3,
           rowGap: 2.5,
         },

--- a/src/pages/home/settings/DeleteAccountDialog.tsx
+++ b/src/pages/home/settings/DeleteAccountDialog.tsx
@@ -51,7 +51,7 @@ const DeleteAccountDialog: FunctionComponent = () => {
       <Button onClick={ handleOpenDialog } variant="secondary" color="magazine">
         Delete account
       </Button>
-      <Dialog open={ isModalOpen }>
+      <Dialog open={ isModalOpen } onClose={ handleCloseDialog }>
         <Formik
           initialValues={ initialValues }
           onSubmit={ handleSubmit }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,6 +4,7 @@ declare module "@mui/material/styles" {
   interface Theme {
     colors: {
       activeBackground: string;
+      backdropBlur: string;
       baseBlue: string;
       baseGreen: string;
       baseOrange: string;
@@ -58,6 +59,7 @@ declare module "@mui/material/styles" {
   interface ThemeOptions {
     colors?: {
       activeBackground?: string;
+      backdropBlur?: string;
       baseBlue?: string;
       baseGreen?: string;
       baseOrange?: string;
@@ -146,6 +148,7 @@ declare module "@mui/material/Typography" {
 
 const colors = {
   activeBackground: "#FFFFFF1A",
+  backdropBlur: "#121214CC",
   baseBlue: "#5091EB",
   baseGreen: "#41BE91",
   baseOrange: "#FF6E32",


### PR DESCRIPTION
Updates:
- Background color of main app changed to black
- Cleaned up index and app css files
- Sidebar border color added
- The following components background were tweaked: form progress stepper, song file and cover art, Dialog backgrounds and backdrops, table pagination, text inputs and text areas
- Delete Account dialog was updated to be in line with other dialog behavior. User is able to click outside of dialog to close dialog.

Notes:
- Connect wallet and invite modal are using different dialogs and aren't in sync with the `Dialog` element