### PR TITLE
Add bottom padding to pages as needed and fix a minor wallet table issue

### DIFF
--- a/src/pages/home/library/Library.tsx
+++ b/src/pages/home/library/Library.tsx
@@ -9,12 +9,13 @@ const Library: FunctionComponent = () => (
   <Container
     maxWidth={ false }
     sx={ {
-      marginX: [null, null, 3],
+      mx: [null, null, 3],
       display: "flex",
       flexDirection: "column",
       flexGrow: 1,
       flexWrap: "nowrap",
       width: "auto",
+      pb: 8,
     } }
   >
     <Routes>

--- a/src/pages/home/owners/Owners.tsx
+++ b/src/pages/home/owners/Owners.tsx
@@ -12,8 +12,8 @@ const Owners: FunctionComponent = () => (
       flexDirection: "column",
       flexGrow: 1,
       flexWrap: "nowrap",
-      marginX: [null, null, 3],
-      paddingBottom: 10.5,
+      mx: [null, null, 3],
+      paddingBottom: 8,
       width: "auto",
     } }
   >

--- a/src/pages/home/wallet/Portfolio.tsx
+++ b/src/pages/home/wallet/Portfolio.tsx
@@ -10,6 +10,10 @@ const Portfolio: FunctionComponent = () => {
   const windowHeight = useWindowDimensions()?.height;
   const windowWidth = useWindowDimensions()?.width;
   const maxListWidth = 700;
+  const SKELETON_PADDING = 200;
+  const ROW_HEIGHT = 50;
+  const DEFAULT_ROWS = 10;
+  const MIN_ROWS = 1;
   const skeletonRef = useRef<HTMLDivElement>();
   const skeletonYPos = skeletonRef.current?.offsetTop || 0;
   const [skeletonRows, setSkeletonRows] = useState<number>(10);
@@ -28,15 +32,20 @@ const Portfolio: FunctionComponent = () => {
 
   useEffect(() => {
     const rowsToRender = windowHeight
-      ? Math.floor((windowHeight - skeletonYPos - 200) / 50)
-      : 10;
+      ? Math.max(
+          Math.floor(
+            (windowHeight - skeletonYPos - SKELETON_PADDING) / ROW_HEIGHT
+          ),
+          MIN_ROWS
+        )
+      : DEFAULT_ROWS;
 
     setSkeletonRows(rowsToRender);
     setRowsPerPage(rowsToRender);
   }, [windowHeight, skeletonYPos]);
 
   return (
-    <Box ref={ skeletonRef } paddingTop={ 2 }>
+    <Box ref={ skeletonRef } pt={ 2 } pb={ 8 }>
       { isLoading ? (
         <SkeletonTable
           cols={

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -124,7 +124,7 @@ const Login: FunctionComponent = () => {
         <HorizontalLine />
       </Stack>
 
-      <Stack my={ 2 } spacing={ 2 } width="100%" alignItems="center">
+      <Stack my={ 2 } spacing={ 2 } width="100%" alignItems="center" pb={ 8 }>
         <GoogleLogin>Continue with Google</GoogleLogin>
         <FacebookLogin>Continue with Facebook</FacebookLogin>
         <LinkedInLogin>Continue with Linkedin</LinkedInLogin>

--- a/src/pages/signUp/Verification.tsx
+++ b/src/pages/signUp/Verification.tsx
@@ -66,7 +66,7 @@ const Verification: FunctionComponent = () => {
         </Stack>
       </Box>
 
-      <Box mb={ 4 } mt={ 2 }>
+      <Box pb={ 4 } mt={ 2 }>
         { showResendLink ? (
           <Typography color="grey100" fontWeight={ 500 }>
             Didn&apos;t receive an email?

--- a/src/pages/signUp/Welcome.tsx
+++ b/src/pages/signUp/Welcome.tsx
@@ -92,7 +92,7 @@ const SignUp: FunctionComponent = () => {
         <HorizontalLine />
       </Stack>
 
-      <Stack my={ 3 } spacing={ 2 } width="100%" alignItems="center">
+      <Stack my={ 3 } spacing={ 2 } width="100%" alignItems="center" pb={ 8 }>
         <GoogleLogin>Join with Google</GoogleLogin>
         <FacebookLogin>Join with Facebook</FacebookLogin>
         <LinkedInLogin>Join with Linkedin</LinkedInLogin>


### PR DESCRIPTION
- Add padding to the bottom of pages where needed when accessing it through smaller screens
- Fix table issue with wallet, where if the height of the window was smaller than the available space to display at least one row, it would fetch for 0 or -1, made it so it renders at least 1 row