### PR TITLE
CU-86a0hrzbd_Alignment-of-Sidebar-Symbols--Words-extra-white-space_David-Kirshon

### DIFF
--- a/src/components/home/SideBarNavLink.tsx
+++ b/src/components/home/SideBarNavLink.tsx
@@ -67,7 +67,7 @@ const SideBarNavLink: FunctionComponent<SideBarNavLinkProps> = ({
     >
       <Stack
         direction="row"
-        spacing={ 2.5 }
+        spacing={ 2 }
         sx={ {
           fontSize: "12px",
           lineHeight: "15px",

--- a/src/components/home/SideBarNavLink.tsx
+++ b/src/components/home/SideBarNavLink.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, FunctionComponent, ReactNode } from "react";
 import { Link, useMatch, useResolvedPath } from "react-router-dom";
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, SvgIconProps } from "@mui/material";
 import theme from "theme";
 
 interface ButtonProps {
@@ -23,7 +23,7 @@ type WrapperProps = LinkProps | ButtonProps | AnchorProps;
 
 interface SideBarNavLinkProps {
   readonly label: string;
-  readonly icon: JSX.Element;
+  readonly Icon: React.ComponentType<SvgIconProps>;
   readonly to?: string;
   readonly href?: string;
   readonly onClick?: VoidFunction;
@@ -45,7 +45,7 @@ const Wrapper: FunctionComponent<WrapperProps> = ({ children, ...props }) => {
 
 const SideBarNavLink: FunctionComponent<SideBarNavLinkProps> = ({
   label,
-  icon,
+  Icon,
   to,
   href,
   onClick,
@@ -92,7 +92,7 @@ const SideBarNavLink: FunctionComponent<SideBarNavLinkProps> = ({
         } }
         data-testid="navStyled"
       >
-        { icon }
+        <Icon sx={ { fontSize: "18px" } } />
         <span>{ label }</span>
       </Stack>
     </Wrapper>

--- a/src/components/test/SideBarNavLink.test.tsx
+++ b/src/components/test/SideBarNavLink.test.tsx
@@ -1,12 +1,18 @@
 import { renderWithContext } from "common";
 import * as routerUtils from "react-router-dom";
-import UploadIcon from "assets/images/UploadIcon";
+import { Upload as UploadIcon } from "@mui/icons-material";
 import theme from "theme";
 import SideBarNavLink from "../home/SideBarNavLink";
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useMatch: jest.fn(),
+}));
+
+// Mock MUI icon component
+jest.mock("@mui/icons-material", () => ({
+  ...jest.requireActual("@mui/icons-material"),
+  Upload: jest.fn(),
 }));
 
 const mockMatch = {
@@ -22,7 +28,7 @@ describe("<SideBarNavLink>", () => {
       jest.spyOn(routerUtils, "useMatch").mockImplementation(() => mockMatch);
 
       const { getByTestId } = renderWithContext(
-        <SideBarNavLink label="Example" icon={ <UploadIcon /> } to="/example" />
+        <SideBarNavLink label="Example" Icon={ UploadIcon } to="/example" />
       );
 
       expect(getByTestId("navStyled")).toHaveStyle(
@@ -36,7 +42,7 @@ describe("<SideBarNavLink>", () => {
       jest.spyOn(routerUtils, "useMatch").mockImplementation(() => null);
 
       const { getByTestId } = renderWithContext(
-        <SideBarNavLink label="Example" icon={ <UploadIcon /> } to="/example" />
+        <SideBarNavLink label="Example" Icon={ UploadIcon } to="/example" />
       );
 
       expect(getByTestId("navStyled")).toHaveStyle("background: transparent;");

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -12,7 +12,7 @@ import Profile from "./profile/Profile";
 import Settings from "./settings/Settings";
 
 const Home: FunctionComponent = () => {
-  const drawerWidth = 240;
+  const drawerWidth = 230;
 
   const theme = useTheme();
 
@@ -26,11 +26,7 @@ const Home: FunctionComponent = () => {
         flexGrow: 1,
       } }
     >
-      <SideBar
-        isMobileOpen={ isMobileOpen }
-        setMobileOpen={ setMobileOpen }
-        drawerWidth={ drawerWidth }
-      />
+      <SideBar isMobileOpen={ isMobileOpen } setMobileOpen={ setMobileOpen } />
 
       <Box
         component="main"

--- a/src/pages/home/SideBar.tsx
+++ b/src/pages/home/SideBar.tsx
@@ -31,7 +31,6 @@ export const SideBar: FunctionComponent<SideBarProps> = (
   props: SideBarProps
 ) => {
   const theme = useTheme();
-  const iconSize = "18px";
 
   const { data: { firstName, lastName, nickname, pictureUrl } = emptyProfile } =
     useGetProfileQuery();
@@ -82,7 +81,7 @@ export const SideBar: FunctionComponent<SideBarProps> = (
         <Box mt={ 4 } mb={ 3 } width="100%">
           <SideBarNavLink
             onClick={ () => props.setMobileOpen(false) }
-            icon={ <UploadIcon sx={ { fontSize: iconSize } } /> }
+            Icon={ UploadIcon }
             label="UPLOAD A SONG"
             to="/home/upload-song"
           />
@@ -94,14 +93,14 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 0.75 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <LibraryIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ LibraryIcon }
               label="LIBRARY"
               to="/home/library"
             />
 
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <CollaboratorsIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ CollaboratorsIcon }
               label="COLLABORATORS"
               to="/home/collaborators"
             />
@@ -114,7 +113,7 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 0.75 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <WalletIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ WalletIcon }
               label="WALLET"
               to="/home/wallet"
             />
@@ -127,14 +126,14 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 0.75 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <ProfileIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ ProfileIcon }
               label="PROFILE"
               to="/home/profile"
             />
 
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <SettingsIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ SettingsIcon }
               label="SETTINGS"
               to="/home/settings"
             />
@@ -147,19 +146,19 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 1.5 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <FaqIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ FaqIcon }
               label="FAQ"
               href={ NEWM_ARTIST_PORTAL_FAQ_URL }
             />
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <AskCommunityIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ AskCommunityIcon }
               label="ASK THE COMMUNITY"
               href={ NEWM_ARTIST_PORTAL_TELEGRAM_URL }
             />
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <SupportIcon sx={ { fontSize: iconSize } } /> }
+              Icon={ SupportIcon }
               label="SUPPORT"
               href={ `mailto: ${NEWM_SUPPORT_EMAIL}` }
             />

--- a/src/pages/home/SideBar.tsx
+++ b/src/pages/home/SideBar.tsx
@@ -183,7 +183,6 @@ export const SideBar: FunctionComponent<SideBarProps> = (
 
 interface ResponsiveSideBarProps {
   isMobileOpen: boolean;
-  drawerWidth: number;
   setMobileOpen: (field: boolean) => void;
 }
 
@@ -208,7 +207,6 @@ const ResponsiveSideBar: FunctionComponent<ResponsiveSideBarProps> = (
           "& .MuiDrawer-paper": {
             overflow: props.isMobileOpen ? "visible" : "hidden",
             boxSizing: "border-box",
-            width: props.drawerWidth,
           },
         } }
       >
@@ -230,7 +228,6 @@ const ResponsiveSideBar: FunctionComponent<ResponsiveSideBarProps> = (
           display: { xs: "none", md: "block" },
           "& .MuiDrawer-paper": {
             boxSizing: "border-box",
-            width: props.drawerWidth,
           },
         } }
         open

--- a/src/pages/home/SideBar.tsx
+++ b/src/pages/home/SideBar.tsx
@@ -3,17 +3,19 @@ import { Box, Drawer, IconButton, Stack, useTheme } from "@mui/material";
 import { Typography } from "elements";
 import { ProfileImage, SideBarHeader, SideBarNavLink } from "components";
 import { emptyProfile, useGetProfileQuery } from "modules/session";
-import UploadIcon from "assets/images/UploadIcon";
-import FoldersIcon from "assets/images/FoldersIcon";
-import PeopleIcon from "assets/images/PeopleIcon";
-import WalletIcon from "assets/images/WalletIcon";
-import StarIcon from "assets/images/StarIcon";
 import NewmLogoSmInverse from "assets/images/NEWM-logo-sm-inverse";
-import MenuOpenIcon from "@mui/icons-material/MenuOpen";
-import EmailIcon from "@mui/icons-material/Email";
-import LiveHelpIcon from "@mui/icons-material/LiveHelp";
-import TelegramIcon from "@mui/icons-material/Telegram";
-import SettingsIcon from "@mui/icons-material/Settings";
+import {
+  Telegram as AskCommunityIcon,
+  PeopleAlt as CollaboratorsIcon,
+  LiveHelp as FaqIcon,
+  FolderCopy as LibraryIcon,
+  MenuOpen as MenuOpenIcon,
+  Star as ProfileIcon,
+  Settings as SettingsIcon,
+  Email as SupportIcon,
+  FileUploadOutlined as UploadIcon,
+  AccountBalanceWalletRounded as WalletIcon,
+} from "@mui/icons-material";
 import {
   NEWM_ARTIST_PORTAL_FAQ_URL,
   NEWM_ARTIST_PORTAL_TELEGRAM_URL,
@@ -29,6 +31,7 @@ export const SideBar: FunctionComponent<SideBarProps> = (
   props: SideBarProps
 ) => {
   const theme = useTheme();
+  const iconSize = "18px";
 
   const { data: { firstName, lastName, nickname, pictureUrl } = emptyProfile } =
     useGetProfileQuery();
@@ -79,7 +82,7 @@ export const SideBar: FunctionComponent<SideBarProps> = (
         <Box mt={ 4 } mb={ 3 } width="100%">
           <SideBarNavLink
             onClick={ () => props.setMobileOpen(false) }
-            icon={ <UploadIcon /> }
+            icon={ <UploadIcon sx={ { fontSize: iconSize } } /> }
             label="UPLOAD A SONG"
             to="/home/upload-song"
           />
@@ -91,14 +94,14 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 0.75 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <FoldersIcon /> }
+              icon={ <LibraryIcon sx={ { fontSize: iconSize } } /> }
               label="LIBRARY"
               to="/home/library"
             />
 
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <PeopleIcon /> }
+              icon={ <CollaboratorsIcon sx={ { fontSize: iconSize } } /> }
               label="COLLABORATORS"
               to="/home/collaborators"
             />
@@ -111,7 +114,7 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 0.75 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <WalletIcon /> }
+              icon={ <WalletIcon sx={ { fontSize: iconSize } } /> }
               label="WALLET"
               to="/home/wallet"
             />
@@ -124,14 +127,14 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 0.75 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <StarIcon /> }
+              icon={ <ProfileIcon sx={ { fontSize: iconSize } } /> }
               label="PROFILE"
               to="/home/profile"
             />
 
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <SettingsIcon sx={ { fontSize: "18px" } } /> }
+              icon={ <SettingsIcon sx={ { fontSize: iconSize } } /> }
               label="SETTINGS"
               to="/home/settings"
             />
@@ -144,19 +147,19 @@ export const SideBar: FunctionComponent<SideBarProps> = (
           <Stack mt={ 1.5 } spacing={ 0.5 } sx={ { width: "100%" } }>
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <LiveHelpIcon sx={ { fontSize: "18px" } } /> }
+              icon={ <FaqIcon sx={ { fontSize: iconSize } } /> }
               label="FAQ"
               href={ NEWM_ARTIST_PORTAL_FAQ_URL }
             />
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <TelegramIcon sx={ { fontSize: "18px" } } /> }
+              icon={ <AskCommunityIcon sx={ { fontSize: iconSize } } /> }
               label="ASK THE COMMUNITY"
               href={ NEWM_ARTIST_PORTAL_TELEGRAM_URL }
             />
             <SideBarNavLink
               onClick={ () => props.setMobileOpen(false) }
-              icon={ <EmailIcon sx={ { fontSize: "18px" } } /> }
+              icon={ <SupportIcon sx={ { fontSize: iconSize } } /> }
               label="SUPPORT"
               href={ `mailto: ${NEWM_SUPPORT_EMAIL}` }
             />


### PR DESCRIPTION
Fixed:
- Removed extra white space between sidebar icons/symbols and words in the Navigation Links
- Migrated Sidebar symbols/icons to MUI sourced to maintain consistent sizing
- Updated sidebar width from 240px to fix alignment discrepancy, also leading to ASK THE COMMUNITY to one line in desktop view

Notes:
- Scroll bar and responsive mobile views affect spacing and sizing on sidebar and will need to be reviewed with design team for consistency, this also include keeping longer text for Navigation links in one line
- Some of the icons/symbols used in figma design aren't currently available within MUI, used closest related symbols to match design aesthetic