### PR TITLE
CU-86a0r3vj4: Move audio tests outside of Yup validation

### DIFF
--- a/src/common/formUtils.ts
+++ b/src/common/formUtils.ts
@@ -47,37 +47,6 @@ const includesGenres = (
   return hasValidGenre;
 };
 
-const createAudioBuffer = async (value: File) => {
-  const audioContext = new (window.AudioContext || window.AudioContext)();
-  const arrayBuffer = await value.arrayBuffer();
-
-  return audioContext.decodeAudioData(arrayBuffer);
-};
-
-const createAsyncAudioTest = (
-  testFn: (audioBuffer: AudioBuffer) => boolean
-) => {
-  return async (value: File) => {
-    if (!value) return false;
-
-    const audioBuffer = await createAudioBuffer(value);
-
-    return testFn(audioBuffer);
-  };
-};
-
-const isFileSizeValid = (value: File) => {
-  if (!value) return false;
-
-  const fileSizeInMB = value.size / (1024 * 1024);
-  const fileSizeInGB = value.size / (1024 * 1024 * 1024);
-
-  return (
-    fileSizeInMB >= AUDIO_MIN_FILE_SIZE_MB &&
-    fileSizeInGB <= AUDIO_MAX_FILE_SIZE_GB
-  );
-};
-
 const BARCODE_CONFIG: Record<BarcodeType | "DEFAULT", BarcodeConfig> = {
   [BarcodeType.UPC]: {
     regEx: REGEX_12_DIGITS_OR_LESS,
@@ -132,9 +101,6 @@ const isAspectRatioOneToOne = async (value: File | null) => {
   return width === height;
 };
 
-const AUDIO_MIN_FILE_SIZE_MB = 1;
-const AUDIO_MAX_FILE_SIZE_GB = 1;
-const AUDIO_MIN_DURATION_SEC = 60;
 const COVERT_ART_MAX_FILE_SIZE_MB = 10;
 
 export const commonYupValidation = {
@@ -229,18 +195,7 @@ export const commonYupValidation = {
     MAX_CHARACTER_COUNT_LONG,
     `Must be ${MAX_CHARACTER_COUNT_LONG} characters or less`
   ),
-  audio: Yup.mixed()
-    .required("This field is required")
-    .test({
-      message: `The file size must be between ${AUDIO_MIN_FILE_SIZE_MB}MB and ${AUDIO_MAX_FILE_SIZE_GB}GB.`,
-      test: isFileSizeValid,
-    })
-    .test({
-      message: `Must be at least ${AUDIO_MIN_DURATION_SEC} seconds.`,
-      test: createAsyncAudioTest(
-        (value) => value.duration >= AUDIO_MIN_DURATION_SEC
-      ),
-    }),
+  audio: Yup.mixed().required("This field is required"),
   releaseDate: (releaseDate: string | undefined) => {
     // If releaseDate is provided, use it.
     // Otherwise, use the minimum time for EVEARA to distribute from now.

--- a/src/components/form/UploadSongField.tsx
+++ b/src/components/form/UploadSongField.tsx
@@ -1,5 +1,5 @@
-import { FunctionComponent } from "react";
-import { Field, FieldProps } from "formik";
+import { FunctionComponent, useEffect, useState } from "react";
+import { Field, FieldProps, useFormikContext } from "formik";
 import UploadSong from "../UploadSong";
 
 interface UploadSongFieldProps {
@@ -7,6 +7,17 @@ interface UploadSongFieldProps {
 }
 
 const UploadSongField: FunctionComponent<UploadSongFieldProps> = ({ name }) => {
+  //isValidationTriggered is used to work between required and custom errors
+  const [isValidationTriggered, setIsValidationTriggered] = useState(false);
+
+  const form = useFormikContext();
+
+  useEffect(() => {
+    if (!isValidationTriggered && (form.isSubmitting || form.isValidating)) {
+      setIsValidationTriggered(true);
+    }
+  }, [form.isSubmitting, form.isValidating, isValidationTriggered]);
+
   return (
     <Field name={ name }>
       { ({ form, field, meta }: FieldProps) => {
@@ -14,9 +25,10 @@ const UploadSongField: FunctionComponent<UploadSongFieldProps> = ({ name }) => {
           <UploadSong
             file={ field.value }
             onChange={ (file) => form.setFieldValue(field.name, file) }
-            onError={ (error: string) => form.setFieldError(field.name, error) }
             onBlur={ () => form.setFieldTouched(field.name) }
             errorMessage={ meta.touched ? meta.error : undefined }
+            isValidationTriggered={ isValidationTriggered }
+            resetValidationTrigger={ () => setIsValidationTriggered(false) }
           />
         );
       } }

--- a/src/components/test/UploadSong.test.tsx
+++ b/src/components/test/UploadSong.test.tsx
@@ -9,16 +9,17 @@ jest.mock("common", () => ({
 describe("<UploadSong>", () => {
   describe("when a file is present", () => {
     it("displays the filename", () => {
-      const { queryByText } = renderWithContext(
+      const { getByText } = renderWithContext(
         <UploadSong
           file={ mockFile }
           onChange={ jest.fn() }
           onBlur={ jest.fn() }
-          onError={ jest.fn() }
+          isValidationTriggered={ false }
+          resetValidationTrigger={ jest.fn() }
         />
       );
 
-      expect(queryByText(mockFile.name)).toBeTruthy();
+      expect(getByText(mockFile.name)).toBeTruthy();
     });
   });
 
@@ -28,7 +29,8 @@ describe("<UploadSong>", () => {
         <UploadSong
           onChange={ jest.fn() }
           onBlur={ jest.fn() }
-          onError={ jest.fn() }
+          isValidationTriggered={ false }
+          resetValidationTrigger={ jest.fn() }
         />
       );
 


### PR DESCRIPTION
Added:
- Custom error messages to handle audio tests on drag/drop

Removed:
- Yup validation for Audio, except for required

Bugs Noted:
- Large files over 100MB+ tend to crash Chrome when added, need to look into chunking bufferArray (see example txt attached)
Load times also take time for large files, noticeable delay of loading not allowing interaction with site, might require a loading UX
- Drag and drops have issues
   - issues with drag drop .mp3, error doesn't appear
   - issues with drag drop once audio file already added
- Noticed issue with Image drop, accepted non 1:1 ratio image and displayed error
- Once fields are already touched, Touching Image drop does not trigger Audio Required test, visa versa does trigger