### PR TITLE
Remove Persistent Overlay for Profile picture and header image

### DIFF
--- a/src/components/UploadImage.tsx
+++ b/src/components/UploadImage.tsx
@@ -37,7 +37,7 @@ export interface UploadImageProps {
   readonly file?: FileWithPreview;
   readonly isAspectRatioOneToOne?: boolean;
   readonly isMinimumSizeDisplayed?: boolean;
-  readonly isMultiButtonLayout?: boolean;
+  readonly hasPreviewOption?: boolean;
   readonly isSuccessIconDisplayed?: boolean;
   readonly maxFileSizeMB?: number;
   readonly minDimensions?: {
@@ -53,7 +53,7 @@ export interface UploadImageProps {
 }
 
 interface ImagePreviewProps extends BoxProps {
-  readonly isMultiButtonLayout?: boolean;
+  readonly hasPersistentOverlay?: boolean;
   readonly imageUrl: string;
 }
 
@@ -71,7 +71,7 @@ const UploadImage: FunctionComponent<UploadImageProps> = ({
   file,
   isAspectRatioOneToOne = false,
   isMinimumSizeDisplayed = true,
-  isMultiButtonLayout = false,
+  hasPreviewOption = false,
   isSuccessIconDisplayed = true,
   maxFileSizeMB,
   minDimensions,
@@ -243,10 +243,10 @@ const UploadImage: FunctionComponent<UploadImageProps> = ({
             onMouseEnter={ () => setIsHovering(true) }
             onMouseLeave={ () => setIsHovering(false) }
             imageUrl={ (file.preview || file) as string }
-            isMultiButtonLayout={ isMultiButtonLayout }
+            hasPersistentOverlay={ hasPreviewOption }
             sx={ { height: 100, ...contentSx } }
           >
-            { !isMultiButtonLayout && (isHovering || isDragActive) ? (
+            { !hasPreviewOption && (isHovering || isDragActive) ? (
               <IconMessage
                 icon={ <AddImageIcon /> }
                 message={ replaceMessage }
@@ -329,7 +329,7 @@ const UploadImage: FunctionComponent<UploadImageProps> = ({
  * layouts and a hover overlay is added for single button layouts.
  */
 const ImagePreview: FunctionComponent<ImagePreviewProps> = ({
-  isMultiButtonLayout,
+  hasPersistentOverlay = false,
   imageUrl,
   children,
   sx,
@@ -344,17 +344,17 @@ const ImagePreview: FunctionComponent<ImagePreviewProps> = ({
         justifyContent: "center",
         alignItems: "stretch",
         flexGrow: 1,
-        background: isMultiButtonLayout
+        background: hasPersistentOverlay
           ? `linear-gradient(0deg, ${overlay}, ${overlay}), url(${imageUrl})`
           : `url(${imageUrl})`,
         backgroundSize: "cover",
         backgroundPosition: "center",
 
-        "&:hover": isMultiButtonLayout
-          ? null
-          : {
+        "&:hover": !hasPersistentOverlay
+          ? {
               backgroundImage: `linear-gradient(0deg, ${overlay}, ${overlay}), url(${imageUrl})`,
-            },
+            }
+          : null,
         ...sx,
       } }
       { ...boxProps }

--- a/src/components/UploadImage.tsx
+++ b/src/components/UploadImage.tsx
@@ -53,6 +53,7 @@ export interface UploadImageProps {
 }
 
 interface ImagePreviewProps extends BoxProps {
+  readonly isMultiButtonLayout?: boolean;
   readonly imageUrl: string;
 }
 
@@ -242,6 +243,7 @@ const UploadImage: FunctionComponent<UploadImageProps> = ({
             onMouseEnter={ () => setIsHovering(true) }
             onMouseLeave={ () => setIsHovering(false) }
             imageUrl={ (file.preview || file) as string }
+            isMultiButtonLayout={ isMultiButtonLayout }
             sx={ { height: 100, ...contentSx } }
           >
             { !isMultiButtonLayout && (isHovering || isDragActive) ? (
@@ -323,9 +325,11 @@ const UploadImage: FunctionComponent<UploadImageProps> = ({
 };
 
 /**
- * Displays a background image with a dark overlay.
+ * Displays a background image. A persistent overlay is added for multi button
+ * layouts and a hover overlay is added for single button layouts.
  */
 const ImagePreview: FunctionComponent<ImagePreviewProps> = ({
+  isMultiButtonLayout,
   imageUrl,
   children,
   sx,
@@ -340,9 +344,17 @@ const ImagePreview: FunctionComponent<ImagePreviewProps> = ({
         justifyContent: "center",
         alignItems: "stretch",
         flexGrow: 1,
-        background: `linear-gradient(0deg, ${overlay}, ${overlay}), url(${imageUrl})`,
+        background: isMultiButtonLayout
+          ? `linear-gradient(0deg, ${overlay}, ${overlay}), url(${imageUrl})`
+          : `url(${imageUrl})`,
         backgroundSize: "cover",
         backgroundPosition: "center",
+
+        "&:hover": isMultiButtonLayout
+          ? null
+          : {
+              backgroundImage: `linear-gradient(0deg, ${overlay}, ${overlay}), url(${imageUrl})`,
+            },
         ...sx,
       } }
       { ...boxProps }

--- a/src/pages/home/library/SongInfo.tsx
+++ b/src/pages/home/library/SongInfo.tsx
@@ -139,7 +139,7 @@ const SongInfo = () => {
                   rootSx={ { width: "100%", alignSelf: "center" } }
                   name="coverArtUrl"
                   emptyMessage="Loading..."
-                  isMultiButtonLayout={ true }
+                  hasPreviewOption={ true }
                   allowImageChange={ false }
                 />
               </Stack>

--- a/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -172,7 +172,7 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
             changeImageButtonText="Change cover"
             emptyMessage="Drag and drop or browse your image"
             isAspectRatioOneToOne
-            isMultiButtonLayout
+            hasPreviewOption
             maxFileSizeMB={ 10 }
             minDimensions={ { width: 1400, height: 1400 } }
             name="coverArtUrl"


### PR DESCRIPTION
Updated:
- Removed persistent overlay on profile images
- Added hover overlay on profile images

[Screencast from 27-09-2023 16:42:01.webm](https://github.com/projectNEWM/newm-artist-portal/assets/86050631/e189ce4e-c697-4f13-b151-9e10ab1ef202)

ClickUp tasks linked:
[Profile picture and header image ](https://app.clickup.com/t/86a0m7n1a)