### PR TITLE
Selecting the dropdown arrow icon to render field options

### DIFF
--- a/src/components/form/DropdownMultiSelectField.tsx
+++ b/src/components/form/DropdownMultiSelectField.tsx
@@ -15,7 +15,7 @@ const DropdownMultiSelectField: ForwardRefRenderFunction<
         handleChange={ (event: SyntheticEvent, value: ReadonlyArray<string>) => {
           form.setFieldValue(field.name, value);
         } }
-        handleBlur={ form.handleBlur }
+        handleFieldBlur={ form.handleBlur }
         ref={ ref }
       />
     ) }

--- a/src/components/form/DropdownMultiSelectField.tsx
+++ b/src/components/form/DropdownMultiSelectField.tsx
@@ -12,10 +12,10 @@ const DropdownMultiSelectField: ForwardRefRenderFunction<
         { ...field }
         { ...props }
         errorMessage={ meta.touched ? meta.error : "" }
+        handleBlur={ form.handleBlur }
         handleChange={ (event: SyntheticEvent, value: ReadonlyArray<string>) => {
           form.setFieldValue(field.name, value);
         } }
-        handleFieldBlur={ form.handleBlur }
         ref={ ref }
       />
     ) }

--- a/src/components/form/DropdownSelectField.tsx
+++ b/src/components/form/DropdownSelectField.tsx
@@ -13,6 +13,7 @@ const DropdownSelectField: ForwardRefRenderFunction<
         { ...props }
         errorMessage={ meta.touched ? meta.error : "" }
         handleChange={ form.handleChange(props.name) }
+        handleFieldBlur={ form.handleBlur }
         ref={ ref }
       />
     ) }

--- a/src/components/form/DropdownSelectField.tsx
+++ b/src/components/form/DropdownSelectField.tsx
@@ -12,8 +12,8 @@ const DropdownSelectField: ForwardRefRenderFunction<
         { ...field }
         { ...props }
         errorMessage={ meta.touched ? meta.error : "" }
+        handleBlur={ form.handleBlur }
         handleChange={ form.handleChange(props.name) }
-        handleFieldBlur={ form.handleBlur }
         ref={ ref }
       />
     ) }

--- a/src/elements/DropdownMultiSelect.tsx
+++ b/src/elements/DropdownMultiSelect.tsx
@@ -62,6 +62,7 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
     getInputProps,
     getListboxProps,
     getOptionProps,
+    getPopupIndicatorProps,
     getRootProps,
     groupedOptions,
     popupOpen,
@@ -95,8 +96,9 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   const showNoResults = !hasResults && popupOpen;
   const displayValue = getDisplayValue();
   const inputProps = getInputProps();
+  const popupIndicatorProps = getPopupIndicatorProps();
   const handleEndAdornmentClick =
-    inputProps.onMouseDown as MouseEventHandler<HTMLOrSVGElement>;
+    popupIndicatorProps.onClick as MouseEventHandler<HTMLOrSVGElement>;
 
   /**
    * This prevents a form submission when input text does not match any options.

--- a/src/elements/DropdownMultiSelect.tsx
+++ b/src/elements/DropdownMultiSelect.tsx
@@ -52,7 +52,7 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
     noResultsText = "Nothing found",
     options,
     placeholder = "Select all that apply",
-    value,
+    value = null,
     handleChange,
     handleFieldBlur,
     ...rest
@@ -78,9 +78,7 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
     options,
     value: value as Array<string>,
     onChange: (event, newValue) => {
-      if (handleChange) {
-        handleChange(event, newValue);
-      }
+      handleChange?.(event, newValue);
     },
     open: isOptionsOpen,
   });
@@ -123,6 +121,9 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
+    // Prevents null TypeError on left arrow "previous" event in useAutocomplete
+    if (event.key === "ArrowLeft") event.stopPropagation();
+
     setIsOptionsOpen(true);
     preventFormSubmit(event);
   };

--- a/src/elements/DropdownMultiSelect.tsx
+++ b/src/elements/DropdownMultiSelect.tsx
@@ -117,14 +117,33 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
 
   const handleBlurEvent = (event: FocusEvent<HTMLInputElement, Element>) => {
     handleFieldBlur?.(event);
+    inputProps.onBlur?.(event);
     setIsOptionsOpen(false);
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    // Prevents null TypeError on left arrow "previous" event in useAutocomplete
-    if (event.key === "ArrowLeft") event.stopPropagation();
+    // Replaces AutoComplete key actions
+    switch (event.key) {
+      case "ArrowLeft": {
+        setIsOptionsOpen(false);
+        // Prevents null TypeError on left arrow "previous" event in useAutocomplete
+        event.stopPropagation();
+        break;
+      }
+      case "ArrowRight": {
+        setIsOptionsOpen(false);
+        break;
+      }
+      case "Escape": {
+        setIsOptionsOpen(false);
+        break;
+      }
+      default: {
+        setIsOptionsOpen(true);
+        break;
+      }
+    }
 
-    setIsOptionsOpen(true);
     preventFormSubmit(event);
   };
 

--- a/src/elements/DropdownMultiSelect.tsx
+++ b/src/elements/DropdownMultiSelect.tsx
@@ -23,13 +23,12 @@ export interface DropdownMultiSelectProps
   extends Omit<HTMLProps<HTMLInputElement>, "as" | "ref" | "value"> {
   readonly disabled?: boolean;
   readonly errorMessage?: string;
+  readonly handleBlur?: (event: FocusEvent<HTMLInputElement, Element>) => void;
   readonly handleChange?: (
     event: SyntheticEvent,
     newValue: ReadonlyArray<string>
   ) => void;
-  readonly handleFieldBlur?: (
-    event: FocusEvent<HTMLInputElement, Element>
-  ) => void;
+
   readonly label?: string;
   readonly name: string;
   readonly tooltipText?: string;
@@ -54,7 +53,7 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
     placeholder = "Select all that apply",
     value = null,
     handleChange,
-    handleFieldBlur,
+    handleBlur,
     ...rest
   },
   ref: ForwardedRef<HTMLInputElement>
@@ -101,22 +100,26 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   const inputProps = getInputProps();
 
   /**
-   * This prevents a form submission when input
-   * text does not match any options.
+   * This prevents a form submission when input text does not match any options.
    */
   const preventFormSubmit = (event: KeyboardEvent): void => {
     if (event.key === "Enter" && value && inputValue !== value[0])
       event.preventDefault();
   };
 
-  // Helpers for handling dropdown options list for integration of
-  // end adornment interactivity
-  const toggleOptionsList = () => {
+  /**
+   *  Dropdown options toggle to handle separate end adornment interactivity
+   */
+  function toggleOptionsList() {
     setIsOptionsOpen(!isOptionsOpen);
-  };
+  }
 
-  const handleBlurEvent = (event: FocusEvent<HTMLInputElement, Element>) => {
-    handleFieldBlur?.(event);
+  /**
+   * Consolidates onBlur events for Formik Field and MUI's useAutocomplete,
+   * and sets dropdown options to close on blur.
+   */
+  const handleBlurEvents = (event: FocusEvent<HTMLInputElement, Element>) => {
+    handleBlur?.(event);
     inputProps.onBlur?.(event);
     setIsOptionsOpen(false);
   };
@@ -177,7 +180,7 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
             }
             errorMessage={ errorMessage }
             name={ name }
-            onBlur={ handleBlurEvent }
+            onBlur={ handleBlurEvents }
             onClick={ toggleOptionsList }
             onKeyDown={ handleKeydown }
           />

--- a/src/elements/DropdownMultiSelect.tsx
+++ b/src/elements/DropdownMultiSelect.tsx
@@ -5,6 +5,7 @@ import {
   HTMLProps,
   SyntheticEvent,
   forwardRef,
+  useState,
 } from "react";
 import useAutocomplete from "@mui/base/useAutocomplete";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -55,6 +56,8 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   },
   ref: ForwardedRef<HTMLInputElement>
 ) => {
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+
   const {
     getInputProps,
     getListboxProps,
@@ -70,12 +73,13 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
     multiple: true,
     disableCloseOnSelect: true,
     options,
-    value,
+    value: value as Array<string>,
     onChange: (event, newValue) => {
       if (handleChange) {
         handleChange(event, newValue);
       }
     },
+    open: isPopupOpen,
   });
 
   const getDisplayValue = () => {
@@ -94,6 +98,15 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   const showNoResults = !hasResults && popupOpen;
   const displayValue = getDisplayValue();
   const inputProps = getInputProps();
+
+  // A helper to toggle the options list
+  const toggleOptionsList = () => {
+    setIsPopupOpen(!isPopupOpen);
+  };
+
+  const handleCloseOptions = () => {
+    setIsPopupOpen(false);
+  };
 
   return (
     <Box sx={ { position: "relative" } }>
@@ -118,7 +131,9 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
             placeholder={ popupOpen ? "Search" : placeholder }
             endAdornment={
               <ArrowDropDownIcon
+                onClick={ toggleOptionsList }
                 sx={ {
+                  cursor: "pointer",
                   color: theme.colors.white,
                   transform: popupOpen ? "rotate(-180deg)" : "rotate(0deg)",
                   transition: "transform 200ms ease-in",
@@ -127,6 +142,11 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
             }
             errorMessage={ errorMessage }
             name={ name }
+            onClick={ () => toggleOptionsList() }
+            closeOptionsBox={ handleCloseOptions }
+            onKeyDownCapture={ () => {
+              !isPopupOpen && setIsPopupOpen(true);
+            } }
           />
         </Stack>
       </div>

--- a/src/elements/DropdownMultiSelect.tsx
+++ b/src/elements/DropdownMultiSelect.tsx
@@ -4,9 +4,9 @@ import {
   ForwardedRef,
   HTMLProps,
   KeyboardEvent,
+  MouseEventHandler,
   SyntheticEvent,
   forwardRef,
-  useState,
 } from "react";
 import useAutocomplete from "@mui/base/useAutocomplete";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -58,8 +58,6 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   },
   ref: ForwardedRef<HTMLInputElement>
 ) => {
-  const [isOptionsOpen, setIsOptionsOpen] = useState(false);
-
   const {
     getInputProps,
     getListboxProps,
@@ -79,7 +77,6 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
     onChange: (event, newValue) => {
       handleChange?.(event, newValue);
     },
-    open: isOptionsOpen,
   });
 
   const getDisplayValue = () => {
@@ -98,6 +95,8 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   const showNoResults = !hasResults && popupOpen;
   const displayValue = getDisplayValue();
   const inputProps = getInputProps();
+  const handleEndAdornmentClick =
+    inputProps.onMouseDown as MouseEventHandler<HTMLOrSVGElement>;
 
   /**
    * This prevents a form submission when input text does not match any options.
@@ -108,43 +107,17 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
   };
 
   /**
-   *  Dropdown options toggle to handle separate end adornment interactivity
-   */
-  function toggleOptionsList() {
-    setIsOptionsOpen(!isOptionsOpen);
-  }
-
-  /**
-   * Consolidates onBlur events for Formik Field and MUI's useAutocomplete,
-   * and sets dropdown options to close on blur.
+   * Consolidates onBlur events for Formik Field and MUI's useAutocomplete.
    */
   const handleBlurEvents = (event: FocusEvent<HTMLInputElement, Element>) => {
     handleBlur?.(event);
     inputProps.onBlur?.(event);
-    setIsOptionsOpen(false);
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    // Replaces AutoComplete key actions
-    switch (event.key) {
-      case "ArrowLeft": {
-        setIsOptionsOpen(false);
-        // Prevents null TypeError on left arrow "previous" event in useAutocomplete
-        event.stopPropagation();
-        break;
-      }
-      case "ArrowRight": {
-        setIsOptionsOpen(false);
-        break;
-      }
-      case "Escape": {
-        setIsOptionsOpen(false);
-        break;
-      }
-      default: {
-        setIsOptionsOpen(true);
-        break;
-      }
+    // Prevents null TypeError on left arrow "previous" event in useAutocomplete
+    if (event.key === "ArrowLeft") {
+      event.stopPropagation();
     }
 
     preventFormSubmit(event);
@@ -169,7 +142,7 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
             placeholder={ popupOpen ? "Search" : placeholder }
             endAdornment={
               <ArrowDropDownIcon
-                onClick={ toggleOptionsList }
+                onClick={ handleEndAdornmentClick }
                 sx={ {
                   cursor: "pointer",
                   color: theme.colors.white,
@@ -181,7 +154,6 @@ const DropdownMultiSelect: ForwardRefRenderFunction<
             errorMessage={ errorMessage }
             name={ name }
             onBlur={ handleBlurEvents }
-            onClick={ toggleOptionsList }
             onKeyDown={ handleKeydown }
           />
         </Stack>

--- a/src/elements/DropdownSelect.tsx
+++ b/src/elements/DropdownSelect.tsx
@@ -105,11 +105,29 @@ const DropdownSelect: ForwardRefRenderFunction<
 
   const handleBlurEvent = (event: FocusEvent<HTMLInputElement, Element>) => {
     handleFieldBlur?.(event);
+    inputProps.onBlur?.(event);
     setIsOptionsOpen(false);
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    setIsOptionsOpen(true);
+    // Replaces AutoComplete key actions
+    switch (event.key) {
+      case "ArrowLeft": {
+        break;
+      }
+      case "ArrowRight": {
+        break;
+      }
+      case "Escape": {
+        setIsOptionsOpen(false);
+        break;
+      }
+      default: {
+        setIsOptionsOpen(true);
+        break;
+      }
+    }
+
     preventFormSubmit(event);
   };
 

--- a/src/elements/DropdownSelect.tsx
+++ b/src/elements/DropdownSelect.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import {
   FocusEvent,
   ForwardRefRenderFunction,
   ForwardedRef,
   HTMLProps,
   KeyboardEvent,
+  MouseEventHandler,
   forwardRef,
-  useState,
 } from "react";
 import useAutocomplete from "@mui/base/useAutocomplete";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -53,8 +52,6 @@ const DropdownSelect: ForwardRefRenderFunction<
   },
   ref: ForwardedRef<HTMLInputElement>
 ) => {
-  const [isOptionsOpen, setIsOptionsOpen] = useState(false);
-
   const {
     getInputProps,
     getListboxProps,
@@ -71,8 +68,6 @@ const DropdownSelect: ForwardRefRenderFunction<
       // or for partial edit of selected input causing invalid undefined error
       if (newValue === null || newValue === undefined) handleChange?.("");
       else handleChange?.(newValue as string);
-
-      setIsOptionsOpen(false);
     },
     // Removes warning for empty string not being a valid option
     isOptionEqualToValue: (option, value) =>
@@ -80,12 +75,13 @@ const DropdownSelect: ForwardRefRenderFunction<
     clearOnBlur: true,
     options,
     value: value as string,
-    open: isOptionsOpen,
   });
 
   const hasResults = groupedOptions.length > 0;
   const showNoResults = !hasResults && popupOpen;
   const inputProps = getInputProps();
+  const handleEndAdornmentClick =
+    inputProps.onMouseDown as MouseEventHandler<HTMLOrSVGElement>;
 
   /**
    * This prevents a form submission when input text does not match any options.
@@ -95,42 +91,11 @@ const DropdownSelect: ForwardRefRenderFunction<
   };
 
   /**
-   *  Dropdown options toggle to handle separate end adornment interactivity
-   */
-  const toggleOptionsList = () => {
-    setIsOptionsOpen(!isOptionsOpen);
-  };
-
-  /**
-   * Consolidates onBlur events for Formik Field and MUI's useAutocomplete,
-   * and sets dropdown options to close on blur.
+   * Consolidates onBlur events for Formik Field and MUI's useAutocomplete.
    */
   const handleBlurEvents = (event: FocusEvent<HTMLInputElement, Element>) => {
     handleBlur?.(event);
     inputProps.onBlur?.(event);
-    setIsOptionsOpen(false);
-  };
-
-  const handleKeydown = (event: KeyboardEvent) => {
-    // Replaces useAutocomplete key actions
-    switch (event.key) {
-      case "ArrowLeft": {
-        break;
-      }
-      case "ArrowRight": {
-        break;
-      }
-      case "Escape": {
-        setIsOptionsOpen(false);
-        break;
-      }
-      default: {
-        setIsOptionsOpen(true);
-        break;
-      }
-    }
-
-    preventFormSubmit(event);
   };
 
   return (
@@ -149,13 +114,15 @@ const DropdownSelect: ForwardRefRenderFunction<
           disabled={ disabled }
           endAdornment={
             <ArrowDropDownIcon
-              onClick={ toggleOptionsList }
-              sx={ {
-                cursor: "pointer",
-                color: theme.colors.white,
-                transform: popupOpen ? "rotate(-180deg)" : "rotate(0deg)",
-                transition: "transform 200ms ease-in",
-              } }
+              onClick={ handleEndAdornmentClick }
+              sx={
+                {
+                  cursor: "pointer",
+                  color: theme.colors.white,
+                  transform: popupOpen ? "rotate(-180deg)" : "rotate(0deg)",
+                  transition: "transform 200ms ease-in",
+                } as React.CSSProperties
+              }
             />
           }
           errorMessage={ errorMessage }
@@ -163,8 +130,7 @@ const DropdownSelect: ForwardRefRenderFunction<
           name={ name }
           placeholder={ placeholder }
           onBlur={ handleBlurEvents }
-          onClick={ toggleOptionsList }
-          onKeyDown={ handleKeydown }
+          onKeyDown={ preventFormSubmit }
         />
       </div>
 

--- a/src/elements/DropdownSelect.tsx
+++ b/src/elements/DropdownSelect.tsx
@@ -21,10 +21,8 @@ export interface DropdownSelectProps
   extends Omit<HTMLProps<HTMLInputElement>, "as" | "ref"> {
   readonly disabled?: boolean;
   readonly errorMessage?: string;
+  readonly handleBlur?: (event: FocusEvent<HTMLInputElement, Element>) => void;
   readonly handleChange?: (newValue: string) => void;
-  readonly handleFieldBlur?: (
-    event: FocusEvent<HTMLInputElement, Element>
-  ) => void;
   readonly label?: string;
   readonly isOptional?: boolean;
   readonly name: string;
@@ -43,7 +41,7 @@ const DropdownSelect: ForwardRefRenderFunction<
     disabled,
     errorMessage,
     handleChange,
-    handleFieldBlur,
+    handleBlur,
     label,
     name,
     noResultsText = "Nothing found",
@@ -90,27 +88,31 @@ const DropdownSelect: ForwardRefRenderFunction<
   const inputProps = getInputProps();
 
   /**
-   * This prevents a form submission when input
-   * text does not match any options.
+   * This prevents a form submission when input text does not match any options.
    */
   const preventFormSubmit = (event: KeyboardEvent): void => {
     if (event.key === "Enter" && inputValue !== value) event.preventDefault();
   };
 
-  // Helpers for handling dropdown options list for integration of
-  // end adornment interactivity
+  /**
+   *  Dropdown options toggle to handle separate end adornment interactivity
+   */
   const toggleOptionsList = () => {
     setIsOptionsOpen(!isOptionsOpen);
   };
 
-  const handleBlurEvent = (event: FocusEvent<HTMLInputElement, Element>) => {
-    handleFieldBlur?.(event);
+  /**
+   * Consolidates onBlur events for Formik Field and MUI's useAutocomplete,
+   * and sets dropdown options to close on blur.
+   */
+  const handleBlurEvents = (event: FocusEvent<HTMLInputElement, Element>) => {
+    handleBlur?.(event);
     inputProps.onBlur?.(event);
     setIsOptionsOpen(false);
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    // Replaces AutoComplete key actions
+    // Replaces useAutocomplete key actions
     switch (event.key) {
       case "ArrowLeft": {
         break;
@@ -160,7 +162,7 @@ const DropdownSelect: ForwardRefRenderFunction<
           label={ label }
           name={ name }
           placeholder={ placeholder }
-          onBlur={ handleBlurEvent }
+          onBlur={ handleBlurEvents }
           onClick={ toggleOptionsList }
           onKeyDown={ handleKeydown }
         />

--- a/src/elements/DropdownSelect.tsx
+++ b/src/elements/DropdownSelect.tsx
@@ -56,6 +56,7 @@ const DropdownSelect: ForwardRefRenderFunction<
     getInputProps,
     getListboxProps,
     getOptionProps,
+    getPopupIndicatorProps,
     getRootProps,
     groupedOptions,
     popupOpen,
@@ -80,8 +81,9 @@ const DropdownSelect: ForwardRefRenderFunction<
   const hasResults = groupedOptions.length > 0;
   const showNoResults = !hasResults && popupOpen;
   const inputProps = getInputProps();
+  const popupIndicatorProps = getPopupIndicatorProps();
   const handleEndAdornmentClick =
-    inputProps.onMouseDown as MouseEventHandler<HTMLOrSVGElement>;
+    popupIndicatorProps.onClick as MouseEventHandler<HTMLOrSVGElement>;
 
   /**
    * This prevents a form submission when input text does not match any options.

--- a/src/elements/DropdownSelect.tsx
+++ b/src/elements/DropdownSelect.tsx
@@ -69,11 +69,17 @@ const DropdownSelect: ForwardRefRenderFunction<
     id: name,
     getOptionLabel: (option) => option,
     onChange: (event, newValue) => {
-      if (handleChange) {
-        handleChange(newValue as string);
-        setIsOptionsOpen(false);
-      }
+      // Updates as empty string instead of invalid null error for empty field
+      // or for partial edit of selected input causing invalid undefined error
+      if (newValue === null || newValue === undefined) handleChange?.("");
+      else handleChange?.(newValue as string);
+
+      setIsOptionsOpen(false);
     },
+    // Removes warning for empty string not being a valid option
+    isOptionEqualToValue: (option, value) =>
+      value === "" ? true : option === value,
+    clearOnBlur: true,
     options,
     value: value as string,
     open: isOptionsOpen,

--- a/src/elements/TextInput.tsx
+++ b/src/elements/TextInput.tsx
@@ -19,7 +19,6 @@ import { Tooltip } from "elements";
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly endAdornment?: JSX.Element;
   readonly errorMessage?: string;
-  readonly closeOptionsBox?: () => void;
   readonly isOptional?: boolean;
   readonly tooltipText?: ReactNode;
   readonly label?: string;
@@ -97,7 +96,6 @@ export const TextInput: ForwardRefRenderFunction<
     maskChar,
     onBlur,
     onFocus,
-    closeOptionsBox,
     startAdornment,
     tooltipText = "",
     widthType = "default",
@@ -132,7 +130,6 @@ export const TextInput: ForwardRefRenderFunction<
     }
 
     setIsFocused(false);
-    closeOptionsBox?.();
   };
 
   return (

--- a/src/elements/TextInput.tsx
+++ b/src/elements/TextInput.tsx
@@ -19,6 +19,7 @@ import { Tooltip } from "elements";
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly endAdornment?: JSX.Element;
   readonly errorMessage?: string;
+  readonly closeOptionsBox?: () => void;
   readonly isOptional?: boolean;
   readonly tooltipText?: ReactNode;
   readonly label?: string;
@@ -96,6 +97,7 @@ export const TextInput: ForwardRefRenderFunction<
     maskChar,
     onBlur,
     onFocus,
+    closeOptionsBox,
     startAdornment,
     tooltipText = "",
     widthType = "default",
@@ -130,6 +132,7 @@ export const TextInput: ForwardRefRenderFunction<
     }
 
     setIsFocused(false);
+    closeOptionsBox?.();
   };
 
   return (


### PR DESCRIPTION
Fix: 
- Dropdown arrow icon for Single and Multi Select Dropdown fields now triggers list of options to display or hide

Also addressed:
- Fixed bug where Single Select Dropdown fields would create error when attempting to clear/edit/empty input, saves changed input as `""` empty string 
- Fixed bug where left arrow would trigger error on Multi Select Dropdown fields

[demo_NEWM-Studio_Dropdown-Arrow-Trigger.webm](https://github.com/projectNEWM/newm-artist-portal/assets/86050631/cb447ff5-e2ba-4219-9847-3eff8ae651e2)
