### PR TITLE
MRKT-39: updates marketplace staging deploy slack hook channel

### DIFF
--- a/.github/workflows/firebase-hosting-deploy-published-release.yml
+++ b/.github/workflows/firebase-hosting-deploy-published-release.yml
@@ -35,5 +35,5 @@ jobs:
               "text": "NEWM Studio updated in production. View at https://newm.studio."
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_STUDIO_WEBHOOK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/firebase-hosting-merge-deploy-newm-marketplace.yml
+++ b/.github/workflows/firebase-hosting-merge-deploy-newm-marketplace.yml
@@ -39,5 +39,5 @@ jobs:
               "text": "NEWM Marketplace updated in staging. View at https://fan.square.newm.io."
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_MARKETPLACE_WEBHOOK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/firebase-hosting-merge-deploy-newm-studio.yml
+++ b/.github/workflows/firebase-hosting-merge-deploy-newm-studio.yml
@@ -39,5 +39,5 @@ jobs:
               "text": "NEWM Studio updated in staging. View at https://artist.garage.newm.io."
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_STUDIO_WEBHOOK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
- Updates the marketplace deploy Slack channel to #newm-marketplace
- Changes existing Slack webhook secret name to be specific to #newm-studio