### PR TITLE
fix: Update outlet profile regex

### DIFF
--- a/apps/studio/src/common/regex.ts
+++ b/apps/studio/src/common/regex.ts
@@ -23,9 +23,11 @@ export const REGEX_JAN_FORMAT = /^(49|45)\d{1,11}$/;
 
 /**
  * Regular expression to match URLs with the specified domain followed by a path.
+ * Optionally match the scheme "http://" or "https://", optionally followed by "www.",
+ * then ensure the URL includes the specified domain and a "/" followed by any characters except for spaces
  */
 const generateRegexForDomainWithPath = (domain: string): RegExp => {
-  return new RegExp(`${domain}/.+`, "i");
+  return new RegExp(`^(https?:\\/\\/(www\\.)?)?${domain.replace(/\./g, "\\.")}(\\/[^\\s]+)`, "i");
 };
 
 export const REGEX_SPOTIFY_PROFILE =


### PR DESCRIPTION
will match:
https://soundcloud.com/xoniyagar
https://www.soundcloud.com/xoniyagar
[soundcloud.com/xoniyagar](http://soundcloud.com/xoniyagar)

will not match:
https://on.soundcloud.com/sKcdC
https://www.on.soundcloud.com/sKcdC
[on.soundcloud.com/sKcdC](http://on.soundcloud.com/sKcdC)