### PR TITLE
Misc fixes

### DIFF
--- a/apps/marketplace/src/components/MoreSongs.tsx
+++ b/apps/marketplace/src/components/MoreSongs.tsx
@@ -18,6 +18,7 @@ const MoreSongs: FunctionComponent<MoreSongsProps> = ({
   const { isLoading, data: sales = [] } = useGetSalesQuery({
     artistIds: artistId ? [artistId] : undefined,
     ids: currentSaleId ? [`-${currentSaleId}`] : undefined,
+    limit: 8,
   });
 
   const title = (

--- a/apps/marketplace/src/components/Sale.tsx
+++ b/apps/marketplace/src/components/Sale.tsx
@@ -15,12 +15,12 @@ import {
 import { Form, Formik } from "formik";
 import { formatNewmAmount, usePlayAudioUrl } from "@newm-web/utils";
 import { useRouter } from "next/navigation";
-import { ItemSkeleton } from "../components";
-import { Sale } from "../modules/sale";
+import { SaleSkeleton } from "../components";
+import { Sale as SaleItem } from "../modules/sale";
 
 interface SaleProps {
   readonly isLoading: boolean;
-  readonly sale?: Sale;
+  readonly sale?: SaleItem;
 }
 
 const Sale: FunctionComponent<SaleProps> = ({ sale, isLoading }) => {
@@ -79,7 +79,7 @@ const Sale: FunctionComponent<SaleProps> = ({ sale, isLoading }) => {
   };
 
   if (isLoading) {
-    return <ItemSkeleton />;
+    return <SaleSkeleton />;
   }
 
   if (!sale) return null;

--- a/apps/marketplace/src/components/SimilarSongs.tsx
+++ b/apps/marketplace/src/components/SimilarSongs.tsx
@@ -15,6 +15,7 @@ const SimilarSongs: FunctionComponent<SimilarSongsProps> = ({
   const { isLoading, data: sales = [] } = useGetSalesQuery({
     artistIds: currentArtistId ? [`-${currentArtistId}`] : undefined,
     genres,
+    limit: 8,
   });
 
   return (

--- a/apps/marketplace/src/components/index.ts
+++ b/apps/marketplace/src/components/index.ts
@@ -5,7 +5,7 @@ export { default as ArtistSongs } from "./ArtistSongs";
 export { default as ArtistSpotlight } from "./ArtistSpotlight";
 export { default as Footer } from "./footer/Footer";
 export { default as Header } from "./header/Header";
-export { default as ItemSkeleton } from "./skeletons/ItemSkeleton";
+export { default as SaleSkeleton } from "./skeletons/SaleSkeleton";
 export { default as MoreSongs } from "./MoreSongs";
 export { default as Sale } from "./Sale";
 export { default as SaleMetadata } from "./SaleMetadata";

--- a/apps/marketplace/src/components/skeletons/SaleSkeleton.tsx
+++ b/apps/marketplace/src/components/skeletons/SaleSkeleton.tsx
@@ -1,7 +1,7 @@
 import { Box, Container, Skeleton, Stack } from "@mui/material";
 import { FunctionComponent } from "react";
 
-const ItemSkeleton: FunctionComponent = () => (
+const SaleSkeleton: FunctionComponent = () => (
   <Container maxWidth="md" sx={ { flexGrow: 1, mt: [0, 0, 5] } }>
     <Stack
       alignItems={ ["center", "center", "start"] }
@@ -51,4 +51,4 @@ const ItemSkeleton: FunctionComponent = () => (
   </Container>
 );
 
-export default ItemSkeleton;
+export default SaleSkeleton;

--- a/packages/components/src/lib/SongCard.tsx
+++ b/packages/components/src/lib/SongCard.tsx
@@ -145,63 +145,67 @@ const SongCard = ({
           </Box>
         </Stack>
         <Stack
-          direction="column"
+          direction="row"
           gap={ 0.5 }
           justifyContent="space-between"
           mt={ 0.5 }
         >
-          <Stack direction="row" gap={ 1 } justifyContent="space-between">
+          <Stack direction="column">
             { !!title && (
               <Typography fontWeight={ 700 } textAlign="left" variant="h4">
                 { title }
               </Typography>
             ) }
 
-            <Stack display="flex" flexDirection="row" whiteSpace="nowrap">
-              { !!priceInNewm && (
-                <Typography
-                  fontSize={ title ? "14px" : "16px" }
-                  fontWeight={ 700 }
-                  sx={ { opacity: 0.9 } }
-                  textAlign="right"
-                  variant="h4"
-                >
-                  { formatNewmAmount(priceInNewm) }
-                </Typography>
-              ) }
-              { !!priceInUsd && (
-                <Typography
-                  fontSize={ title ? "14px" : "15px" }
-                  variant="subtitle1"
-                >
-                  &nbsp;(≈ { currency(priceInUsd).format() })
-                </Typography>
-              ) }
-            </Stack>
+            { !!subtitle && (
+              <Typography
+                fontWeight={ 500 }
+                role={ onSubtitleClick ? "button" : undefined }
+                sx={
+                  onSubtitleClick
+                    ? {
+                        "&:hover": { textDecoration: "underline" },
+                        cursor: "pointer",
+                        width: "fit-content",
+                      }
+                    : undefined
+                }
+                tabIndex={ onSubtitleClick ? 0 : undefined }
+                textAlign="left"
+                variant="subtitle1"
+                onClick={ handleSubtitleClick }
+                onKeyDown={ handleKeyPress(handleSubtitleClick) }
+              >
+                { subtitle }
+              </Typography>
+            ) }
           </Stack>
 
-          { !!subtitle && (
-            <Typography
-              fontWeight={ 500 }
-              role={ onSubtitleClick ? "button" : undefined }
-              sx={
-                onSubtitleClick
-                  ? {
-                      "&:hover": { textDecoration: "underline" },
-                      cursor: "pointer",
-                      width: "fit-content",
-                    }
-                  : undefined
-              }
-              tabIndex={ onSubtitleClick ? 0 : undefined }
-              textAlign="left"
-              variant="subtitle1"
-              onClick={ handleSubtitleClick }
-              onKeyDown={ handleKeyPress(handleSubtitleClick) }
-            >
-              { subtitle }
-            </Typography>
-          ) }
+          <Stack
+            display="flex"
+            flexDirection={ title ? "column" : "row" }
+            whiteSpace="nowrap"
+          >
+            { !!priceInNewm && (
+              <Typography
+                fontSize={ title ? "15px" : "16px" }
+                fontWeight={ 700 }
+                sx={ { opacity: 0.9 } }
+                textAlign="right"
+                variant="h4"
+              >
+                { formatNewmAmount(priceInNewm) }
+              </Typography>
+            ) }
+            { !!priceInUsd && (
+              <Typography
+                fontSize={ title ? "12px" : "15px" }
+                variant="subtitle1"
+              >
+                &nbsp;(≈ { currency(priceInUsd).format() })
+              </Typography>
+            ) }
+          </Stack>
         </Stack>
       </Stack>
     </Clickable>

--- a/packages/components/src/lib/SongCard.tsx
+++ b/packages/components/src/lib/SongCard.tsx
@@ -188,7 +188,6 @@ const SongCard = ({
           >
             { !!priceInNewm && (
               <Typography
-                fontSize={ title ? "15px" : "16px" }
                 fontWeight={ 700 }
                 sx={ { opacity: 0.9 } }
                 textAlign="right"

--- a/packages/components/src/lib/skeletons/SongCardSkeleton.tsx
+++ b/packages/components/src/lib/skeletons/SongCardSkeleton.tsx
@@ -29,10 +29,15 @@ const SongCardSkeleton: FunctionComponent<SongCardSkeletonProps> = ({
     >
       <Skeleton height="100%" variant="rectangular" width="100%" />
       <Stack direction="row" justifyContent="space-between">
-        { isTitleVisible && <Skeleton height={ 30 } width={ 100 } /> }
-        { isPriceVisible && <Skeleton height={ 30 } width={ 80 } /> }
+        <Stack direction="column">
+          { isTitleVisible && <Skeleton height={ 30 } width={ 100 } /> }
+          { isSubtitleVisible && <Skeleton height={ 20 } width={ 60 } /> }
+        </Stack>
+        <Stack alignItems="flex-end" direction="column">
+          { isPriceVisible && <Skeleton height={ 30 } width={ 80 } /> }
+          { isPriceVisible && <Skeleton height={ 18 } width={ 60 } /> }
+        </Stack>
       </Stack>
-      { isSubtitleVisible && <Skeleton height={ 20 } width={ 60 } /> }
     </Box>
   </Stack>
 );


### PR DESCRIPTION
- Updates song card price layout to stack vertically.
- limits "More from {artist}" and "Similar songs" to 8 songs to not make it difficult to scroll to other sections. Post-MVP, some sort of "View all" button can be added.