### PR TITLE
MRKT-93: format stream token NEWM values

### DIFF
--- a/apps/marketplace/project.json
+++ b/apps/marketplace/project.json
@@ -29,7 +29,7 @@
         "development": {
           "buildTarget": "marketplace:build:development",
           "dev": true,
-          "port": 3000
+          "port": 4200
         },
         "production": {
           "buildTarget": "marketplace:build:production",

--- a/apps/marketplace/project.json
+++ b/apps/marketplace/project.json
@@ -29,7 +29,7 @@
         "development": {
           "buildTarget": "marketplace:build:development",
           "dev": true,
-          "port": 4200
+          "port": 3000
         },
         "production": {
           "buildTarget": "marketplace:build:production",

--- a/apps/marketplace/src/modules/sale/utils.ts
+++ b/apps/marketplace/src/modules/sale/utils.ts
@@ -13,6 +13,8 @@ export const transformApiSale = (apiSale: ApiSale): Sale => {
 
   return {
     ...sale,
+    // TODO: look into back-end returning value with correct decimal places
+    costAmount: sale.costAmount / 1000000,
     song: {
       ...song,
       isExplicit: parentalAdvisory === "Explicit",

--- a/packages/components/src/lib/SongCard.tsx
+++ b/packages/components/src/lib/SongCard.tsx
@@ -232,6 +232,7 @@ const SongCard = ({
 
           { priceVariant === "text" && (
             <Stack
+              alignItems="flex-end"
               display="flex"
               flexDirection={ title ? "column" : "row" }
               whiteSpace="nowrap"

--- a/packages/components/src/lib/SongCard.tsx
+++ b/packages/components/src/lib/SongCard.tsx
@@ -11,6 +11,7 @@ import { PlayArrow, Stop } from "@mui/icons-material";
 import { bgImage } from "@newm-web/assets";
 import {
   formatNewmAmount,
+  formatUsdAmount,
   getImageSrc,
   resizeCloudinaryImage,
 } from "@newm-web/utils";
@@ -252,7 +253,7 @@ const SongCard = ({
                   fontSize={ title ? "12px" : "15px" }
                   variant="subtitle1"
                 >
-                  &nbsp;(≈ { currency(priceInUsd).format() })
+                  &nbsp;(≈ { formatUsdAmount(priceInUsd) })
                 </Typography>
               ) }
             </Stack>

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -1,5 +1,3 @@
-import currency from "currency.js";
-
 /**
  * Formats a numerical NEWM amount with the correct decimal
  * places and symbol.
@@ -7,9 +5,17 @@ import currency from "currency.js";
 export const formatNewmAmount = (amount?: number, includeSymbol = true) => {
   if (!amount) return "";
 
-  return currency(amount, {
-    pattern: "# !",
-    precision: 1,
-    symbol: includeSymbol ? "Ɲ" : "",
+  const withDecimals = amount.toFixed(3);
+  const withoutTrailingZeroes = parseFloat(withDecimals)
+  const withSymbol = includeSymbol ? `${withoutTrailingZeroes}`
+
+  const formattedAmount = currency(amount, {
+    // pattern: "# !",
+    // precision: 3,
+    // symbol: includeSymbol ? "Ɲ" : "",
   }).format();
+
+  const withoutTrailingZeros = parseFloat(formattedAmount).toString();
+
+  return withoutTrailingZeros;
 };

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -19,8 +19,8 @@ export const formatNewmAmount = (amount?: number, includeSymbol = true) => {
  * rather than the standard two, based on the exchange rate
  * for NEWM to USD.
  */
-export const formatUsdAmount = (amount?: number) => {
+export const formatUsdAmount = (amount?: number, precision = 3) => {
   if (!amount) return "";
 
-  return currency(amount, { precision: 3 }).format();
+  return currency(amount, { precision }).format();
 };

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -1,3 +1,5 @@
+import currency from "currency.js";
+
 /**
  * Formats a numerical NEWM amount with the correct decimal
  * places and symbol.
@@ -5,17 +7,9 @@
 export const formatNewmAmount = (amount?: number, includeSymbol = true) => {
   if (!amount) return "";
 
-  const withDecimals = amount.toFixed(3);
-  const withoutTrailingZeroes = parseFloat(withDecimals)
-  const withSymbol = includeSymbol ? `${withoutTrailingZeroes}`
-
-  const formattedAmount = currency(amount, {
-    // pattern: "# !",
-    // precision: 3,
-    // symbol: includeSymbol ? "Ɲ" : "",
+  return currency(amount, {
+    pattern: "# !",
+    precision: 2,
+    symbol: includeSymbol ? "Ɲ" : "",
   }).format();
-
-  const withoutTrailingZeros = parseFloat(formattedAmount).toString();
-
-  return withoutTrailingZeros;
 };

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -13,3 +13,14 @@ export const formatNewmAmount = (amount?: number, includeSymbol = true) => {
     symbol: includeSymbol ? "Ɲ" : "",
   }).format();
 };
+
+/**
+ * Formats a numerical USD amount to three decimal places
+ * rather than the standard two, based on the exchange rate
+ * for NEWM to USD.
+ */
+export const formatUsdAmount = (amount?: number) => {
+  if (!amount) return "";
+
+  return currency(amount, { precision: 3 }).format();
+};


### PR DESCRIPTION
- Converts sale NEWM cost to correct value
- Updates NEWM conversion util to display two decimals places instead of one to reflect required precision for individual stream token prices
- Updates song card approximate USD value from two to three decimal places to match Studio [Create sale mock-ups](https://www.figma.com/design/zrn01ZR2zFeLiKBebEYI1v/NEWM-Studio---Final-Designs?node-id=10091-734&t=5KOyOWRyvxFYG3jL-0) and required precision for individual stream token prices

<img width="1278" alt="Screen Shot 2024-07-02 at 7 36 07 PM" src="https://github.com/projectNEWM/newm-web/assets/5877597/9c213386-709b-4a8a-ba79-11a9eb4f0cae">
