### PR TITLE
MRKT-94: adds unsupported browser banner to apps

### DIFF
--- a/apps/marketplace/src/app/layout.tsx
+++ b/apps/marketplace/src/app/layout.tsx
@@ -4,7 +4,10 @@ import { Stack, ThemeProvider } from "@mui/material";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v13-appRouter";
 import { FunctionComponent, ReactNode } from "react";
 import theme from "@newm-web/theme";
-import { StyledComponentsRegistry } from "@newm-web/components";
+import {
+  StyledComponentsRegistry,
+  UnsupportedBrowserBanner,
+} from "@newm-web/components";
 import { Provider } from "react-redux";
 import { AudioProvider } from "@newm-web/audio";
 import { Footer, Header } from "../components";
@@ -48,6 +51,7 @@ const RootLayout: FunctionComponent<RootLayoutProps> = ({ children }) => {
               <ThemeProvider theme={ theme }>
                 <AudioProvider>
                   <Toast />
+                  <UnsupportedBrowserBanner />
 
                   <Stack flexGrow={ 1 } justifyContent="space-between">
                     <Stack justifyContent="flex-start">

--- a/apps/mobile-wallet-connector/src/app/layout.tsx
+++ b/apps/mobile-wallet-connector/src/app/layout.tsx
@@ -5,7 +5,10 @@ import { Provider } from "react-redux";
 import { Container, Stack, ThemeProvider } from "@mui/material";
 import { NEWMLogo } from "@newm-web/assets";
 import theme from "@newm-web/theme";
-import { StyledComponentsRegistry } from "@newm-web/components";
+import {
+  StyledComponentsRegistry,
+  UnsupportedBrowserBanner,
+} from "@newm-web/components";
 import "./global.css";
 import store from "../store";
 import { ConnectWallet, Toast } from "../components";
@@ -49,7 +52,9 @@ const RootLayout: FunctionComponent<RootLayoutProps> = ({ children }) => {
           <AppRouterCacheProvider options={ { enableCssLayer: true } }>
             <Provider store={ store }>
               <ThemeProvider theme={ theme }>
+                <UnsupportedBrowserBanner />
                 <Toast />
+
                 <Stack
                   alignItems="flex-end"
                   minHeight={ ["68px", "68px", "44px"] }

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -6,6 +6,7 @@ import theme from "@newm-web/theme";
 import { PersistGate } from "redux-persist/integration/react";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { GOOGLE_CLIENT_ID } from "@newm-web/env";
+import { UnsupportedBrowserBanner } from "@newm-web/components";
 import {
   Background,
   ConnectWalletModal,
@@ -50,6 +51,7 @@ const App = () => {
             <ProgressBarModal />
             <UpdateWalletAddressModal />
             <WalletEnvMismatchModal />
+            <UnsupportedBrowserBanner />
             <ScrollToTop />
 
             <Background>

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react": "18.2.0",
         "react-apple-signin-auth": "^1.1.0",
         "react-audio-visualize": "^1.1.0",
-        "react-device-detect": "^2.2.2",
+        "react-device-detect": "^2.2.3",
         "react-dom": "18.2.0",
         "react-dropzone": "^14.2.3",
         "react-ga4": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "18.2.0",
     "react-apple-signin-auth": "^1.1.0",
     "react-audio-visualize": "^1.1.0",
-    "react-device-detect": "^2.2.2",
+    "react-device-detect": "^2.2.3",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",
     "react-ga4": "^2.1.0",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -16,6 +16,7 @@ export * from "./lib/SongCard";
 export { default as SongCard } from "./lib/SongCard";
 export { default as SongCardSkeleton } from "./lib/skeletons/SongCardSkeleton";
 export { default as StyledComponentsRegistry } from "./lib/nextjs/StyledComponentsRegistry";
+export { default as UnsupportedBrowserBanner } from "./lib/UnsupportedBrowserBanner";
 export { default as WalletEnvMismatchModal } from "./lib/modals/WalletEnvMismatchModal";
 export * from "./lib/modals/WalletModal";
 export { default as WalletModal } from "./lib/modals/WalletModal";

--- a/packages/components/src/lib/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/lib/UnsupportedBrowserBanner.tsx
@@ -37,10 +37,12 @@ const UnsupportedBrowserBanner: FunctionComponent = () => {
     <Stack
       alignItems="center"
       justifyContent="center"
+      position="relative"
       py={ 2 }
       sx={ {
         backgroundColor: theme.colors.grey600,
       } }
+      zIndex={ 1000000 }
     >
       <Container maxWidth="lg">
         <Alert

--- a/packages/components/src/lib/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/lib/UnsupportedBrowserBanner.tsx
@@ -1,0 +1,71 @@
+import { Container, Stack, useTheme } from "@mui/material";
+import { Alert, Button, Typography } from "@newm-web/elements";
+import { browserName } from "react-device-detect";
+import { FunctionComponent, useEffect, useState } from "react";
+
+const UnsupportedBrowserBanner: FunctionComponent = () => {
+  const theme = useTheme();
+
+  const [isVisible, setIsVisible] = useState(false);
+
+  const fullSupportBrowsers = ["Chrome", "Brave", "Edge"];
+  const limitedSupportBrowsers = ["Firefox"];
+  const isFullSupport = fullSupportBrowsers.includes(browserName);
+  const isLimitedSupport = limitedSupportBrowsers.includes(browserName);
+
+  const title = isLimitedSupport
+    ? "Limited browser support"
+    : "Unsupported browser";
+
+  const message = isLimitedSupport
+    ? `This browser has limited Cardano wallet extension support. Chrome, 
+      Brave, or Edge are recommended for the best experience.`
+    : `This browser is not currently supported by Cardano wallet extensions.
+       Please switch to Chrome, Brave, or Edge for the best experience.`;
+
+  /**
+   * Toggle display after component mounts to avoid Next.js
+   * hydration mismatch error.
+   */
+  useEffect(() => {
+    setIsVisible(!isFullSupport);
+  }, [isFullSupport]);
+
+  if (!isVisible) return null;
+
+  return (
+    <Stack
+      alignItems="center"
+      justifyContent="center"
+      py={ 2 }
+      sx={ {
+        backgroundColor: theme.colors.grey600,
+      } }
+    >
+      <Container maxWidth="lg">
+        <Alert
+          action={
+            <Button
+              color="yellow"
+              sx={ { textTransform: "none" } }
+              variant="outlined"
+              onClick={ () => setIsVisible(false) }
+            >
+              Dismiss
+            </Button>
+          }
+          severity="warning"
+        >
+          <Stack spacing={ 0.5 }>
+            <Typography color="yellow">{ title }</Typography>
+            <Typography color="yellow" fontWeight={ 400 } variant="subtitle1">
+              { message }
+            </Typography>
+          </Stack>
+        </Alert>
+      </Container>
+    </Stack>
+  );
+};
+
+export default UnsupportedBrowserBanner;


### PR DESCRIPTION
Adds "Unsupported browser banner" to Studio, Marketplace, and Mobile Wallet Connector apps

<img width="1512" alt="Screen Shot 2024-07-23 at 12 06 01 AM" src="https://github.com/user-attachments/assets/d3099728-1f63-48ca-ba2a-d6003b7f1d0c">
