### PR TITLE
Prevents sending recaptcha headers with lambda api requests

### DIFF
--- a/apps/studio/src/api/lambda/api.ts
+++ b/apps/studio/src/api/lambda/api.ts
@@ -11,7 +11,7 @@ import { fetchBaseQueryWithReauth, prepareHeaders } from "../utils";
 
 const baseQuery = axiosBaseQuery({
   baseUrl: baseUrls.lambda,
-  prepareHeaders,
+  prepareHeaders: (api, headers) => prepareHeaders(api, headers, false),
 });
 
 const api = createApi({

--- a/apps/studio/src/api/utils.ts
+++ b/apps/studio/src/api/utils.ts
@@ -118,10 +118,13 @@ export const getRecaptchaHeaders = async (api: BaseQueryApi) => {
  */
 export const prepareHeaders = async (
   api: BaseQueryApi,
-  headers: AxiosRequestConfig["headers"]
+  headers: AxiosRequestConfig["headers"],
+  shouldIncludeRecaptchaHeaders = true
 ) => {
   const authHeaders = getAuthHeaders(api);
-  const recaptchaHeaders = await getRecaptchaHeaders(api);
+  const recaptchaHeaders = shouldIncludeRecaptchaHeaders
+    ? await getRecaptchaHeaders(api)
+    : {};
 
   return {
     ...authHeaders,


### PR DESCRIPTION
Resolves the issue where the artist agreement generation endpoint returned a CORS error due to not allowing recaptcha headers.