### PR TITLE
Replace studio firebase workflows

### DIFF
--- a/.github/workflows/aws-hosting-merge-deploy-newm-marketplace.yml
+++ b/.github/workflows/aws-hosting-merge-deploy-newm-marketplace.yml
@@ -39,3 +39,15 @@ jobs:
         run: |
           npm install --prefix .github/workflows/cdk
           APPNAME=marketplace APPID=Marketplace QUALIFIER=Garage NEXT_PUBLIC_ENV=staging NEXT_PUBLIC_RECAPTCHA_SITE_KEY_STAGING=${{ secrets.RECAPTCHA_SITE_KEY_STAGING }} NEXT_PUBLIC_DEXHUNTER_MARKETPLACE_PARTNER_CODE=${{ secrets.DEXHUNTER_MARKETPLACE_PARTNER_CODE }} NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }} npm run --prefix .github/workflows/cdk cdk:deploy deploy -- --require-approval never
+        
+      - name: Send update to slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "NEWM Marketplace updated in staging. View at https://fan.square.newm.io ."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_MARKETPLACE_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/aws-hosting-merge-deploy-newm-studio.yml
+++ b/.github/workflows/aws-hosting-merge-deploy-newm-studio.yml
@@ -27,10 +27,24 @@ jobs:
           VITE_DEXHUNTER_STUDIO_PARTNER_CODE: ${{ secrets.DEXHUNTER_STUDIO_PARTNER_CODE }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VITE_ENV: staging
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_GITHUB_DEPLOY_ROLE_ARN_GARAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Deploy to S3
         run: aws --region ${{ secrets.AWS_REGION }} s3 sync ./dist/apps/studio s3://${{ secrets.AWS_STUDIO_BUCKET_GARAGE }} --no-progress --delete
+
+      - name: Send update to slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          payload: |
+            {
+              "text": "NEWM Studio updated in staging. View at https://artist.garage.newm.io ."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_STUDIO_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/firebase-hosting-deploy-published-release-newm-studio.yml
+++ b/.github/workflows/firebase-hosting-deploy-published-release-newm-studio.yml
@@ -1,0 +1,46 @@
+name: Deploy NEWM Studio app to production on published release
+on:
+  release:
+    types: [published]
+jobs:
+  build_and_deploy_studio_release:
+    if: ${{ startsWith(github.event.release.tag_name, 'studio') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+      - run: npx nx build-with-sentry studio
+        env:
+          VITE_APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          VITE_GA_STUDIO_ID: ${{ secrets.GA_STUDIO_ID }}
+          VITE_RECAPTCHA_SITE_KEY_PROD: ${{ secrets.RECAPTCHA_SITE_KEY_PROD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_ENV: production
+
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        id: deploy
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NEWM_STUDIO }}"
+          channelId: live
+          projectId: "${{ secrets.FIREBASE_PROJECT_ID_NEWM_STUDIO }}"
+          target: studio
+
+      - name: Send update to slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          payload: |
+            {
+              "text": "NEWM Studio updated in production. View at https://newm.studio. View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event.release.tag_name }}."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_STUDIO_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/firebase-hosting-deploy-published-release-newm-studio.yml
+++ b/.github/workflows/firebase-hosting-deploy-published-release-newm-studio.yml
@@ -17,6 +17,7 @@ jobs:
       - run: npm ci
       - run: npx nx build-with-sentry studio
         env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
           VITE_APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           VITE_GA_STUDIO_ID: ${{ secrets.GA_STUDIO_ID }}

--- a/.github/workflows/firebase-hosting-merge-deploy-newm-studio.yml
+++ b/.github/workflows/firebase-hosting-merge-deploy-newm-studio.yml
@@ -1,0 +1,45 @@
+name: Deploy NEWM Studio to Firebase Hosting on merge
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/firebase-hosting-merge-deploy-newm-studio.yml
+      - apps/studio/**
+      - packages/**
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install
+      - run: npx nx build-with-sentry studio
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+          VITE_APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          VITE_GA_STUDIO_ID: ${{ secrets.GA_STUDIO_ID }}
+          VITE_RECAPTCHA_SITE_KEY_STAGING: ${{ secrets.RECAPTCHA_SITE_KEY_STAGING }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_ENV: staging
+
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        id: deploy
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_NEWM_ARTIST_PORTAL }}"
+          channelId: live
+          projectId: "${{ secrets.FIREBASE_PROJECT_ID_NEWM_ARTIST_PORTAL }}"
+          target: studio
+
+      - name: Send update to slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          payload: |
+            {
+              "text": "NEWM Studio updated in staging. View at https://artist.garage.newm.io."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_STUDIO_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Re-adds Studio Firebase deployment workflows. These can be deleted once the Studio domains are pointing towards the AWS deployments.