### PR TITLE
Fixes similar artists loading edge case bug

### DIFF
--- a/apps/marketplace/src/components/SimilarArtists.tsx
+++ b/apps/marketplace/src/components/SimilarArtists.tsx
@@ -13,12 +13,12 @@ const SimilarArtists: FunctionComponent<SimilarArtistsProps> = ({
   genre,
 }) => {
   const limit = 6;
-  const skip = !artistId || !genre;
+  const skip = !artistId;
 
   const { isLoading, data: artists = [] } = useGetArtistsQuery(
     {
-      genres: genre ? [genre] : undefined,
-      ids: artistId ? [`-${artistId}`] : undefined,
+      genres: genre ? [genre] : [],
+      ids: [`-${artistId}`],
       limit,
     },
     { skip }


### PR DESCRIPTION
Fixes a bug where the "Similar artists" section would continuously show the loading UI if an artist hadn't been assigned a genre yet.