### PR TITLE
MRKT-161: Ensures Sale purchase button numbers are formatted with commas

### DIFF
--- a/packages/elements/src/lib/NumericInput.tsx
+++ b/packages/elements/src/lib/NumericInput.tsx
@@ -25,22 +25,17 @@ export const NumericInput: ForwardRefRenderFunction<
   NumericInputProps
 > = ({ type, onChange, ...props }, ref) => {
   /**
-   * Converts the comma formatted string input value
-   * to a number and calls the onChange prop.
+   * Converts the event target's value to a number
+   * and calls the onChange prop.
    */
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
       const numberValue = Number(event.target.value.replace(/,/g, ""));
 
-      onChange({
-        ...event,
-        target: {
-          ...event.target,
-          name: event.target.name,
-          // eslint-disable-next-line
-          value: numberValue as any,
-        },
-      });
+      event.target.type = "number";
+      event.target.valueAsNumber = numberValue;
+
+      onChange(event);
     }
   };
 

--- a/packages/elements/src/lib/NumericInput.tsx
+++ b/packages/elements/src/lib/NumericInput.tsx
@@ -30,7 +30,8 @@ export const NumericInput: ForwardRefRenderFunction<
    */
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
-      const numberValue = Number(event.target.value.replace(/,/g, ""));
+      const formattedValue = event.target.value.replace(/,/g, "");
+      const numberValue = Number(formattedValue);
 
       event.target.type = "number";
       event.target.valueAsNumber = numberValue;

--- a/packages/elements/src/lib/NumericInput.tsx
+++ b/packages/elements/src/lib/NumericInput.tsx
@@ -25,8 +25,8 @@ export const NumericInput: ForwardRefRenderFunction<
   NumericInputProps
 > = ({ type, onChange, ...props }, ref) => {
   /**
-   * Converts the comma formatted string to a number value
-   * and calls the onChange prop.
+   * Converts the comma formatted string input value
+   * to a number and calls the onChange prop.
    */
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (onChange) {

--- a/packages/elements/src/lib/NumericInput.tsx
+++ b/packages/elements/src/lib/NumericInput.tsx
@@ -25,16 +25,22 @@ export const NumericInput: ForwardRefRenderFunction<
   NumericInputProps
 > = ({ type, onChange, ...props }, ref) => {
   /**
-   * Removes any commas that were added when formatting the
-   * input value and then calls the onChange prop.
+   * Converts the comma formatted string to a number value
+   * and calls the onChange prop.
    */
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
-      const formattedValue = event.target.value.replace(/,/g, "");
+      const numberValue = Number(event.target.value.replace(/,/g, ""));
 
-      event.target.value = formattedValue;
-
-      onChange(event);
+      onChange({
+        ...event,
+        target: {
+          ...event.target,
+          name: event.target.name,
+          // eslint-disable-next-line
+          value: numberValue as any,
+        },
+      });
     }
   };
 


### PR DESCRIPTION
The NumericInput component converts the input value from a number to a string. This ensures the value is a number, to match the `number` input type functionality. 

The NumericInput value being a string, instead of a number, was preventing the stream tokens value on the Sale submit button from being formatted with commas correctly.

<img width="463" alt="Screen Shot 2024-09-25 at 5 36 44 PM" src="https://github.com/user-attachments/assets/48f68cbb-0a5b-4288-9df1-03aa985501a0">
