### PR TITLE
[STUD-349, MRKT-161]: numeric input fixes

### DIFF
--- a/apps/marketplace/src/components/Sale.tsx
+++ b/apps/marketplace/src/components/Sale.tsx
@@ -281,7 +281,11 @@ const Sale: FunctionComponent<SaleProps> = ({
                         </Typography>
                         <Stack direction={ "row" }>
                           <Box maxWidth={ "150px" }>
-                            <TextInputField name="streamTokens" type="number" />
+                            <TextInputField
+                              name="streamTokens"
+                              placeholder="0"
+                              type="number"
+                            />
                           </Box>
                           <Typography
                             alignSelf="center"

--- a/packages/elements/src/lib/NumericInput.tsx
+++ b/packages/elements/src/lib/NumericInput.tsx
@@ -30,11 +30,13 @@ export const NumericInput: ForwardRefRenderFunction<
    */
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
-      const formattedValue = event.target.value.replace(/,/g, "");
-      const numberValue = Number(formattedValue);
+      const value = event.target.value;
+      const numberValue = value ? Number(value.replace(/,/g, "")) : null;
 
-      event.target.type = "number";
-      event.target.valueAsNumber = numberValue;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const newTarget = event.target as any;
+      newTarget.value = numberValue;
+      event.target = newTarget;
 
       onChange(event);
     }


### PR DESCRIPTION
Fixes a couple of issues with the numeric input:
- Inputing a number larger than 999 when creating a sale would reset the value to 0.
- Deleting all numbers in an input would set the value to 0. It's now set to undefined, which is a better user experience.