### PR TITLE
MRKT-154: incorrect NEWM purchase fee

### DIFF
--- a/apps/marketplace/src/components/modals/PurchaseStreamTokensModal.tsx
+++ b/apps/marketplace/src/components/modals/PurchaseStreamTokensModal.tsx
@@ -7,7 +7,10 @@ import {
   formatNewmAmount,
   formatUsdAmount,
 } from "@newm-web/utils";
-import { useGetAdaUsdConversionRateQuery } from "../../modules/wallet/api";
+import {
+  useGetAdaUsdConversionRateQuery,
+  useGetNewmUsdConversionRateQuery,
+} from "../../modules/wallet/api";
 
 interface PurchaseStreamTokensModalProps {
   readonly isLoading: boolean;
@@ -41,13 +44,13 @@ const PurchaseStreamTokensModal: FunctionComponent<
   const { data: { usdPrice: adaUsdConversionRate = 0 } = {} } =
     useGetAdaUsdConversionRateQuery();
   const { data: { usdPrice: newmUsdConversionRate = 0 } = {} } =
-    useGetAdaUsdConversionRateQuery();
+    useGetNewmUsdConversionRateQuery();
 
   const newmTransactionFeeUsd = 0.5;
   const newmTransactionFeeNewm =
-    (newmTransactionFeeUsd * newmUsdConversionRate) / LOVELACE_CONVERSION;
+    newmTransactionFeeUsd / (newmUsdConversionRate / LOVELACE_CONVERSION);
   const adaTransactionFeeUsd =
-    (TRANSACTION_FEE_IN_ADA * adaUsdConversionRate) / LOVELACE_CONVERSION;
+    TRANSACTION_FEE_IN_ADA * (adaUsdConversionRate / LOVELACE_CONVERSION);
 
   return (
     <Modal
@@ -125,7 +128,8 @@ const PurchaseStreamTokensModal: FunctionComponent<
                 </Typography>
                 <Typography variant="h4">
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
-                    (≈ { formatUsdAmount(totalPurchaseValueUsd, 2) }){ " " }
+                    (≈{ " " }
+                    { formatUsdAmount(totalPurchaseValueUsd, { precision: 2 }) }){ " " }
                   </Typography>
                   { formatNewmAmount(totalPurchaseValueNewm) }
                 </Typography>
@@ -156,7 +160,7 @@ const PurchaseStreamTokensModal: FunctionComponent<
                 <Typography variant="subtitle1">NEWM fee</Typography>
                 <Typography variant="h4">
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
-                    { formatUsdAmount(newmTransactionFeeUsd, 2) }
+                    { formatUsdAmount(newmTransactionFeeUsd, { precision: 2 }) }
                   </Typography>
                   { formatNewmAmount(newmTransactionFeeNewm) }
                 </Typography>
@@ -169,7 +173,7 @@ const PurchaseStreamTokensModal: FunctionComponent<
                 <Typography variant="subtitle1">Transaction fee</Typography>
                 <Typography variant="h4">
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
-                    { formatUsdAmount(adaTransactionFeeUsd, 2) }{ " " }
+                    { formatUsdAmount(adaTransactionFeeUsd, { precision: 2 }) }{ " " }
                   </Typography>
                   ₳ { TRANSACTION_FEE_IN_ADA }
                 </Typography>

--- a/apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx
+++ b/apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx
@@ -140,7 +140,7 @@ export const CreateSale = () => {
           const formattedPerTokenPrice =
             saleCurrency === Currency.USD.name
               ? formatUsdAmount(perTokenPrice)
-              : formatNewmAmount(perTokenPrice, true);
+              : formatNewmAmount(perTokenPrice);
 
           return (
             <Form

--- a/apps/studio/src/pages/home/library/MarketplaceTab/StartSaleModal.tsx
+++ b/apps/studio/src/pages/home/library/MarketplaceTab/StartSaleModal.tsx
@@ -9,6 +9,7 @@ import {
   LOVELACE_CONVERSION,
   formatNewmAmount,
   formatPercentageAdaptive,
+  formatUsdAmount,
 } from "@newm-web/utils";
 import { Currency } from "@newm-web/types";
 import { useGetNewmUsdConversionRateQuery } from "../../../../modules/crypto";
@@ -139,12 +140,9 @@ const StartSaleModal: FunctionComponent<StartSaleModalProps> = ({
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
                     { isNEWMPriceUnavailable
                       ? "(≈ $ N/A)"
-                      : `(≈ ${currency(totalSaleValueInUSD, {
-                          precision: 3,
-                          symbol: "$",
-                        }).format()})` }
+                      : `(≈ ${formatUsdAmount(totalSaleValueInUSD)})` }
                   </Typography>
-                  { formatNewmAmount(totalSaleValueInNEWM, true) }
+                  { formatNewmAmount(totalSaleValueInNEWM) }
                 </Typography>
               </Stack>
               <Stack
@@ -159,12 +157,9 @@ const StartSaleModal: FunctionComponent<StartSaleModalProps> = ({
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
                     { isNEWMPriceUnavailable
                       ? "(≈ $ N/A)"
-                      : `(≈ ${currency(pricePerStreamTokenInUSD, {
-                          precision: 3,
-                          symbol: "$",
-                        }).format()})` }
+                      : `(≈ ${formatUsdAmount(pricePerStreamTokenInUSD)})` }
                   </Typography>
-                  { formatNewmAmount(totalSaleValueInNEWM / tokensToSell, true) }
+                  { formatNewmAmount(totalSaleValueInNEWM / tokensToSell) }
                 </Typography>
               </Stack>
             </Stack>

--- a/apps/studio/src/pages/home/wallet/EarningsSummaryModal.tsx
+++ b/apps/studio/src/pages/home/wallet/EarningsSummaryModal.tsx
@@ -77,7 +77,8 @@ const EarningsSummaryModal: FunctionComponent<
                 <Typography variant="subtitle1">Earnings</Typography>
                 <Typography variant="h4">
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
-                    (≈ { formatUsdAmount(unclaimedEarningsInUSD, 2) }){ " " }
+                    (≈{ " " }
+                    { formatUsdAmount(unclaimedEarningsInUSD, { precision: 2 }) }){ " " }
                   </Typography>
                   { formatNewmAmount(unclaimedEarningsInNEWM) }
                 </Typography>
@@ -93,7 +94,10 @@ const EarningsSummaryModal: FunctionComponent<
                   <Typography component="span" mr={ 0.5 } variant="subtitle2">
                     (≈ { formatUsdAmount(transactionFeeInUSD) }){ " " }
                   </Typography>
-                  { formatAdaAmount(transactionFeeInADA, false) } ₳
+                  { formatAdaAmount(transactionFeeInADA, {
+                    includeSymbol: false,
+                  }) }{ " " }
+                  ₳
                 </Typography>
               </Stack>
             </Stack>

--- a/packages/components/src/lib/buttons/DisconnectWalletButton.tsx
+++ b/packages/components/src/lib/buttons/DisconnectWalletButton.tsx
@@ -246,7 +246,7 @@ const DisconnectWalletButton: FunctionComponent<
                   fontWeight={ 400 }
                   variant="h5"
                 >
-                  (≈{ formatUsdAmount(newmUsdBalance, 2) })
+                  (≈{ formatUsdAmount(newmUsdBalance, { precision: 2 }) })
                 </Typography>
               </Stack>
 
@@ -263,7 +263,7 @@ const DisconnectWalletButton: FunctionComponent<
                   fontWeight={ 400 }
                   variant="h5"
                 >
-                  (≈{ formatUsdAmount(adaUsdBalance, 2) })
+                  (≈{ formatUsdAmount(adaUsdBalance, { precision: 2 }) })
                 </Typography>
               </Stack>
             </Stack>

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -8,16 +8,26 @@ export const NEWM_POLICY_ID = isProd
   : "769c4c6e9bc3ba5406b9b89fb7beb6819e638ff2e2de63f008d5bcff";
 export const NEWM_ASSET_NAME = isProd ? "4e45574d" : "744e45574d";
 
+interface FormatCurrencyOptions {
+  readonly includeSymbol?: boolean;
+  readonly precision?: number;
+}
+
 /**
  * Formats a numerical NEWM amount with the correct decimal
  * places and symbol.
  */
-export const formatNewmAmount = (amount?: number, includeSymbol = true) => {
+export const formatNewmAmount = (
+  amount?: number,
+  options: FormatCurrencyOptions = { includeSymbol: true, precision: 2 }
+) => {
   if (!amount) return "0 Ɲ";
+
+  const { includeSymbol = true, precision = 2 } = options;
 
   return currency(amount, {
     pattern: "# !",
-    precision: 2,
+    precision,
     symbol: includeSymbol ? "Ɲ" : "",
   }).format();
 };
@@ -26,12 +36,17 @@ export const formatNewmAmount = (amount?: number, includeSymbol = true) => {
  * Formats a numerical ADA amount with the correct decimal
  * places and symbol.
  */
-export const formatAdaAmount = (amount?: number, includeSymbol = true) => {
+export const formatAdaAmount = (
+  amount?: number,
+  options: FormatCurrencyOptions = { includeSymbol: true, precision: 2 }
+) => {
   if (!amount) return "₳ 0";
+
+  const { includeSymbol = true, precision = 2 } = options;
 
   return currency(amount, {
     pattern: "! #",
-    precision: 2,
+    precision,
     symbol: includeSymbol ? "₳" : "",
   }).format();
 };
@@ -41,10 +56,18 @@ export const formatAdaAmount = (amount?: number, includeSymbol = true) => {
  * rather than the standard two, based on the exchange rate
  * for NEWM to USD.
  */
-export const formatUsdAmount = (amount?: number, precision = 3) => {
+export const formatUsdAmount = (
+  amount?: number,
+  options: FormatCurrencyOptions = { includeSymbol: true, precision: 4 }
+) => {
   if (!amount) return "$0";
 
-  return currency(amount, { precision }).format();
+  const { includeSymbol = true, precision = 4 } = options;
+
+  return currency(amount, {
+    precision,
+    symbol: includeSymbol ? "$" : "",
+  }).format();
 };
 
 export const Currency = {


### PR DESCRIPTION
- Corrects NEWM fee amount for purchase stream tokens modal.

### Also

- Updates decimal place for individual stream token USD price from 3 to 4 places, as 3 was determined to be insufficient for smaller sales. A longer term fix will be to dynamically determine the decimal places based on the amount.


<img width="538" alt="Screen Shot 2024-10-21 at 11 46 23 PM" src="https://github.com/user-attachments/assets/8a800f22-294b-418c-bfeb-26941eb9b848">