### PR TITLE
STUD-359: removes create sale email toggle

### DIFF
--- a/apps/studio/src/pages/home/library/ViewDetails.tsx
+++ b/apps/studio/src/pages/home/library/ViewDetails.tsx
@@ -12,7 +12,6 @@ import MintSong from "./MintSong";
 import SongInfo from "./SongInfo";
 import { SongRouteParams } from "./types";
 import { MarketplaceTab } from "./MarketplaceTab";
-import { useGetProfileQuery } from "../../../modules/session";
 import { NEWM_SUPPORT_EMAIL, isSongEditable } from "../../../common";
 import { setToastMessage } from "../../../modules/ui";
 import {
@@ -65,8 +64,6 @@ const ViewDetails: FunctionComponent = () => {
 
   const { songId } = useParams<"songId">() as SongRouteParams;
 
-  const { data: profile } = useGetProfileQuery();
-
   const {
     data: { title, coverArtUrl, mintingStatus } = emptySong,
     error,
@@ -83,9 +80,7 @@ const ViewDetails: FunctionComponent = () => {
   ].includes(mintingStatus);
 
   const isManageMarketplaceSalesEnabled =
-    profile?.email === "sickcitycleveland@gmail.com" ??
-    clientConfig?.featureFlags?.manageMarketplaceSalesEnabled ??
-    false;
+    clientConfig?.featureFlags?.manageMarketplaceSalesEnabled ?? false;
 
   const shouldRenderMarketplaceTab =
     !isClientConfigLoading &&


### PR DESCRIPTION
Removes temporary code to limit access to create sale tab. The feature flag has been turned back off in production, so it will still be unavailable there.