### PR TITLE
Adds new-password autocomplete props

### DIFF
--- a/apps/studio/src/pages/forgotPassword/ResetPassword.tsx
+++ b/apps/studio/src/pages/forgotPassword/ResetPassword.tsx
@@ -38,6 +38,7 @@ const ResetPassword: FunctionComponent = () => {
       >
         <PasswordInputField
           aria-label="Enter your new password"
+          autoComplete="new-password"
           externalMaskPassword={ maskPassword }
           handlePressEndAdornment={ togglePasswordMask }
           name="newPassword"
@@ -46,6 +47,7 @@ const ResetPassword: FunctionComponent = () => {
         />
         <PasswordInputField
           aria-label="Confirm your new password"
+          autoComplete="new-password"
           externalMaskPassword={ maskPassword }
           handlePressEndAdornment={ togglePasswordMask }
           name="confirmPassword"

--- a/apps/studio/src/pages/home/settings/Settings.tsx
+++ b/apps/studio/src/pages/home/settings/Settings.tsx
@@ -155,12 +155,14 @@ const Settings: FunctionComponent = () => {
                       } }
                     >
                       <PasswordInputField
+                        autoComplete="new-password"
                         label="NEW PASSWORD"
                         name="newPassword"
                         placeholder="New password"
                         showEndAdornment={ showEndAdornment }
                       />
                       <PasswordInputField
+                        autoComplete="new-password"
                         label="RETYPE NEW PASSWORD"
                         name="confirmPassword"
                         placeholder="New password"

--- a/apps/studio/src/pages/signUp/Welcome.tsx
+++ b/apps/studio/src/pages/signUp/Welcome.tsx
@@ -59,6 +59,7 @@ const SignUp: FunctionComponent = () => {
         />
         <PasswordInputField
           aria-label="Password input field"
+          autoComplete="new-password"
           externalMaskPassword={ maskPassword }
           handlePressEndAdornment={ togglePasswordMask }
           name="newPassword"
@@ -66,6 +67,7 @@ const SignUp: FunctionComponent = () => {
         />
         <PasswordInputField
           aria-label="Confirm password input field"
+          autoComplete="new-password"
           externalMaskPassword={ maskPassword }
           handlePressEndAdornment={ togglePasswordMask }
           name="confirmPassword"


### PR DESCRIPTION
Adds `autoComplete="new-password"` to new password inputs so the Chrome autofill doesn't hamper the user experience.