### PR TITLE
fix: Update release links for Slack notifications

### DIFF
--- a/.github/workflows/aws-hosting-deploy-published-release-newm-marketplace.yml
+++ b/.github/workflows/aws-hosting-deploy-published-release-newm-marketplace.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "NEWM Marketplace updated in production. View at https://newm.marketplace . View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event.release.tag_name }} ."
+              "text": "NEWM Marketplace updated in production. View at https://newm.marketplace . View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }} ."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_MARKETPLACE_WEBHOOK }}

--- a/.github/workflows/aws-hosting-deploy-published-release-newm-mobile-wallet-connector.yml
+++ b/.github/workflows/aws-hosting-deploy-published-release-newm-mobile-wallet-connector.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "NEWM Mobile Wallet Connector updated in production. View at https://tools.newm.io/wallet-connect . View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event.release.tag_name }} ."
+              "text": "NEWM Mobile Wallet Connector updated in production. View at https://tools.newm.io/wallet-connect . View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }} ."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_MOBILE_WALLET_CONNECTOR_WEBHOOK }}

--- a/.github/workflows/aws-hosting-deploy-published-release-newm-tools.yml
+++ b/.github/workflows/aws-hosting-deploy-published-release-newm-tools.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "NEWM Tools updated in production. View at https://tools.newm.io . View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event.release.tag_name }} ."
+              "text": "NEWM Tools updated in production. View at https://tools.newm.io . View release notes at https://github.com/projectNEWM/newm-web/releases/tag/${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }} ."
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWM_TOOLS_WEBHOOK }}


### PR DESCRIPTION
Currently listing https://github.com/projectNEWM/newm-web/releases/tag/ which is a broken link.

This change will ensure that the correct release notes link is sent
to Slack for the NEWM Marketplace, Mobile Wallet Connector, and
Tools apps based on the event type triggering the workflow.