### PR TITLE
STUD-486: PayPal Payment UI/UX Updates

### DIFF
--- a/apps/studio/src/common/paypalUtils.ts
+++ b/apps/studio/src/common/paypalUtils.ts
@@ -1,5 +1,10 @@
 let paypalPopup: Window | null = null;
 
+const paypalLoadingPopupWidth = 300;
+const paypalLoadingPopupHeight = 225;
+const paypalResizePopupWidth = 400;
+const paypalResizePopupHeight = 650;
+
 const calculatePopUpLocation = (width: number, height: number) => {
   const openerX = (window.screenX ?? (window as any).screenLeft ?? 0) as number;
   const openerY = (window.screenY ?? (window as any).screenTop ?? 0) as number;
@@ -15,8 +20,14 @@ const calculatePopUpLocation = (width: number, height: number) => {
 };
 
 export const openPayPalPopup = (): Window | null => {
+  const { left, top } = calculatePopUpLocation(
+    paypalLoadingPopupWidth,
+    paypalResizePopupHeight
+  );
+
   // No "noopener"/"noreferrer" so window.opener works for postMessage
-  const features = `width=300,height=300,left=${window.screenX},top=${window.screenY},menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=yes`;
+  const features = `width=${paypalLoadingPopupWidth},height=${paypalLoadingPopupHeight},
+  left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=yes`;
 
   paypalPopup =
     window.open(
@@ -39,8 +50,11 @@ export const navigatePayPalPopup = async (url: string): Promise<boolean> => {
   }
 
   try {
-    paypalPopup.resizeTo(400, 650);
-    const { left, top } = calculatePopUpLocation(400, 650);
+    paypalPopup.resizeTo(paypalResizePopupWidth, paypalResizePopupHeight);
+    const { left, top } = calculatePopUpLocation(
+      paypalResizePopupWidth,
+      paypalResizePopupHeight
+    );
     paypalPopup.moveTo(left, top);
   } catch {
     // Intentionally ignore: some browsers/OSes block programmatic move/resize.

--- a/apps/studio/src/modules/song/thunks.ts
+++ b/apps/studio/src/modules/song/thunks.ts
@@ -169,6 +169,13 @@ export const uploadSong = createAsyncThunk(
 
       if ("error" in uploadSongAudioResponse) throw new UploadSongError();
 
+      const paymentMessage =
+        body.paymentType === PaymentType.PAYPAL
+          ? "Creating PayPal order. " +
+            "Please complete PayPal payment when prompted."
+          : "Requesting minting payment. " +
+            "Please sign transaction when prompted.";
+
       if (body.isMinting) {
         const collaborators = generateCollaborators(
           body.owners,
@@ -233,9 +240,8 @@ export const uploadSong = createAsyncThunk(
           setProgressBarModal({
             animationSeconds: 6,
             disclaimer: progressDisclaimer,
-            message:
-              "Requesting minting payment. " +
-              "Please sign transaction when prompted.",
+            message: paymentMessage,
+
             progress: 95,
           })
         );
@@ -252,10 +258,7 @@ export const uploadSong = createAsyncThunk(
         setProgressBarModal({
           animationSeconds: 0.25,
           disclaimer: progressDisclaimer,
-          message: body.isMinting
-            ? "Requesting minting payment. " +
-              "Please sign transaction when prompted."
-            : "Uploading song audio...",
+          message: body.isMinting ? paymentMessage : "Uploading song audio...",
           progress: 100,
         })
       );

--- a/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
@@ -66,7 +66,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
     if (values.paymentType === PaymentType.PAYPAL) {
       openPayPalPopup(); // opens synchronously; avoids popup blocker
     }
-    submitForm(); // your thunk will later navigate the popup to approval URL
+    submitForm(); // will later navigate the paypal popup to the approval URL
   };
 
   return (
@@ -258,7 +258,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                       <Typography variant="subtitle2">
                         (
                         { displayPrices?.dspPrice
-                          ? formatNewmAmount(Number(displayPrices?.dspPrice), {
+                          ? formatNewmAmount(Number(displayPrices.dspPrice), {
                               includeEstimateSymbol: true,
                               precision: 2,
                             })
@@ -285,38 +285,20 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                         } }
                       >
                         { displayPrices?.dspPriceUsd
-                          ? formatUsdAmount(
-                              Number(displayPrices?.dspPriceUsd),
-                              {
-                                precision: 2,
-                              }
-                            )
+                          ? formatUsdAmount(Number(displayPrices.dspPriceUsd), {
+                              precision: 2,
+                            })
                           : "N/A" }
                       </Typography>
                     </>
                   ) : (
-                    <>
-                      <Typography variant="subtitle2">
-                        (
-                        { displayPrices?.dspPrice
-                          ? formatNewmAmount(Number(displayPrices?.dspPrice), {
-                              includeEstimateSymbol: true,
-                              precision: 2,
-                            })
-                          : "N/A" }
-                        )
-                      </Typography>
-                      <Typography>
-                        { displayPrices?.dspPriceUsd
-                          ? formatUsdAmount(
-                              Number(displayPrices?.dspPriceUsd),
-                              {
-                                precision: 2,
-                              }
-                            )
-                          : "N/A" }
-                      </Typography>
-                    </>
+                    <Typography>
+                      { displayPrices?.dspPriceUsd
+                        ? formatUsdAmount(Number(displayPrices.dspPriceUsd), {
+                            precision: 2,
+                          })
+                        : "N/A" }
+                    </Typography>
                   ) }
                 </Stack>
               </Stack>
@@ -332,10 +314,13 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { songEstimate?.mintPriceAda && (
-                    <Typography variant="subtitle2">
+                    <Typography
+                      display={ isNewmPayment ? "block" : "none" }
+                      variant="subtitle2"
+                    >
                       (
                       { displayPrices?.mintPrice
-                        ? formatNewmAmount(Number(displayPrices?.mintPrice), {
+                        ? formatNewmAmount(Number(displayPrices.mintPrice), {
                             includeEstimateSymbol: true,
                             precision: 2,
                           })
@@ -345,7 +330,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                   ) }
                   <Typography>
                     { displayPrices?.mintPriceUsd
-                      ? formatUsdAmount(Number(displayPrices?.mintPriceUsd), {
+                      ? formatUsdAmount(Number(displayPrices.mintPriceUsd), {
                           precision: 2,
                         })
                       : "N/A" }
@@ -364,10 +349,13 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { songEstimate?.collabPriceAda && (
-                    <Typography variant="subtitle2">
+                    <Typography
+                      display={ isNewmPayment ? "block" : "none" }
+                      variant="subtitle2"
+                    >
                       (
                       { displayPrices?.collabPrice
-                        ? formatNewmAmount(Number(displayPrices?.collabPrice), {
+                        ? formatNewmAmount(Number(displayPrices.collabPrice), {
                             includeEstimateSymbol: true,
                             precision: 2,
                           })
@@ -377,7 +365,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                   ) }
                   <Typography>
                     { displayPrices?.collabPriceUsd
-                      ? formatUsdAmount(Number(displayPrices?.collabPriceUsd), {
+                      ? formatUsdAmount(Number(displayPrices.collabPriceUsd), {
                           precision: 2,
                         })
                       : "N/A" }
@@ -399,10 +387,13 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                 <Typography>Total</Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { songEstimate?.adaPrice && (
-                    <Typography variant="subtitle2">
+                    <Typography
+                      display={ isNewmPayment ? "block" : "none" }
+                      variant="subtitle2"
+                    >
                       (
                       { displayPrices?.price
-                        ? formatNewmAmount(Number(displayPrices?.price), {
+                        ? formatNewmAmount(Number(displayPrices.price), {
                             includeEstimateSymbol: true,
                             precision: 2,
                           })

--- a/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
@@ -161,12 +161,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
   };
 
   return (
-    <Dialog
-      fullWidth={ true }
-      open={ open }
-      sx={ { "& .MuiDialog-paper": { maxWidth: 512, width: "100%" } } }
-      onClose={ onClose }
-    >
+    <Dialog fullWidth={ true } open={ open } onClose={ onClose }>
       <DialogTitle sx={ { pb: 0, pt: 3 } }>
         <Typography fontSize={ 20 } fontWeight={ 800 } variant="body2">
           Release Summary

--- a/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
@@ -70,7 +70,12 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
   };
 
   return (
-    <Dialog fullWidth={ true } open={ open } onClose={ onClose }>
+    <Dialog
+      fullWidth={ true }
+      open={ open }
+      sx={ { "& .MuiDialog-paper": { maxWidth: 512, width: "100%" } } }
+      onClose={ onClose }
+    >
       <DialogTitle sx={ { pb: 0, pt: 3 } }>
         <Typography fontSize={ 20 } fontWeight={ 800 } variant="body2">
           Release Summary
@@ -146,7 +151,13 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                         } }
                       />
                     }
-                    label={ <Typography>Pay with PayPal</Typography> }
+                    label={
+                      <Typography
+                        fontWeight={ theme.typography.fontWeightMedium }
+                      >
+                        Pay with PayPal, Credit, or Debit Card
+                      </Typography>
+                    }
                     sx={ {
                       background: isPaypalPayment
                         ? theme.gradients.activeBackground
@@ -182,21 +193,36 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
               } }
             >
               <Stack direction="row" justifyContent="space-between">
-                <Typography sx={ { color: theme.colors.grey200 } }>
+                <Typography
+                  sx={ {
+                    color: theme.colors.grey200,
+                    fontWeight: theme.typography.fontWeightRegular,
+                  } }
+                >
                   Release name
                 </Typography>
                 <Typography>{ values.title }</Typography>
               </Stack>
 
               <Stack direction="row" justifyContent="space-between">
-                <Typography sx={ { color: theme.colors.grey200 } }>
+                <Typography
+                  sx={ {
+                    color: theme.colors.grey200,
+                    fontWeight: theme.typography.fontWeightRegular,
+                  } }
+                >
                   Number of collaborators
                 </Typography>
                 <Typography>{ values.owners.length }</Typography>
               </Stack>
 
               <Stack direction="row" justifyContent="space-between">
-                <Typography sx={ { color: theme.colors.grey200 } }>
+                <Typography
+                  sx={ {
+                    color: theme.colors.grey200,
+                    fontWeight: theme.typography.fontWeightRegular,
+                  } }
+                >
                   Release date
                 </Typography>
                 <Typography>
@@ -218,7 +244,12 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
               } }
             >
               <Stack direction="row" justifyContent="space-between">
-                <Typography sx={ { color: theme.colors.grey200 } }>
+                <Typography
+                  sx={ {
+                    color: theme.colors.grey200,
+                    fontWeight: theme.typography.fontWeightRegular,
+                  } }
+                >
                   Distribution cost
                 </Typography>
                 <Stack direction={ "row" } gap={ 1 }>
@@ -291,7 +322,12 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
               </Stack>
 
               <Stack direction="row" justifyContent="space-between">
-                <Typography sx={ { color: theme.colors.grey200 } }>
+                <Typography
+                  sx={ {
+                    color: theme.colors.grey200,
+                    fontWeight: theme.typography.fontWeightRegular,
+                  } }
+                >
                   Stream Token minting
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
@@ -307,7 +343,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                       )
                     </Typography>
                   ) }
-                  <Typography fontWeight={ 600 }>
+                  <Typography>
                     { displayPrices?.mintPriceUsd
                       ? formatUsdAmount(Number(displayPrices?.mintPriceUsd), {
                           precision: 2,
@@ -318,7 +354,12 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
               </Stack>
 
               <Stack direction="row" justifyContent="space-between">
-                <Typography sx={ { color: theme.colors.grey200 } }>
+                <Typography
+                  sx={ {
+                    color: theme.colors.grey200,
+                    fontWeight: theme.typography.fontWeightRegular,
+                  } }
+                >
                   Royalty splits
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
@@ -334,7 +375,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                       )
                     </Typography>
                   ) }
-                  <Typography fontWeight={ 600 }>
+                  <Typography>
                     { displayPrices?.collabPriceUsd
                       ? formatUsdAmount(Number(displayPrices?.collabPriceUsd), {
                           precision: 2,
@@ -355,7 +396,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
               } }
             >
               <Stack direction="row" justifyContent="space-between">
-                <Typography fontWeight={ 600 }>Total</Typography>
+                <Typography>Total</Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { songEstimate?.adaPrice && (
                     <Typography variant="subtitle2">
@@ -369,7 +410,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                       )
                     </Typography>
                   ) }
-                  <Typography fontWeight={ 600 }>
+                  <Typography>
                     { displayPrices?.priceUsd
                       ? formatUsdAmount(Number(displayPrices?.priceUsd), {
                           precision: 2,
@@ -379,8 +420,8 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
                 </Stack>
               </Stack>
             </Stack>
-          </Stack>{ " " }
-          <Typography variant="subtitle2">
+          </Stack>
+          <Typography mt={ 0.5 } variant="subtitle2">
             Total does not include the Cardano blockchain network fee. Fee
             prices are not guaranteed, costs may vary.
           </Typography>

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -12,6 +12,7 @@ interface FormatCurrencyOptions {
   readonly includeCurrencySymbol?: boolean;
   readonly includeEstimateSymbol?: boolean;
   readonly precision?: number;
+  readonly returnZeroValue?: boolean;
 }
 
 /**
@@ -24,15 +25,23 @@ export const formatNewmAmount = (
     includeCurrencySymbol: true,
     includeEstimateSymbol: false,
     precision: 3,
+    returnZeroValue: true,
   }
 ) => {
-  if (!amount) return "Ɲ0";
-
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 3,
+    returnZeroValue = true,
   } = options;
+
+  if (!amount) {
+    if (returnZeroValue) {
+      return "Ɲ0";
+    } else {
+      return "N/A";
+    }
+  }
 
   if (precision === 3 && amount < 0.001 && amount > 0) {
     return "< 0.001 Ɲ";
@@ -57,15 +66,23 @@ export const formatAdaAmount = (
     includeCurrencySymbol: true,
     includeEstimateSymbol: false,
     precision: 2,
+    returnZeroValue: true,
   }
 ) => {
-  if (!amount) return "₳0";
-
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 2,
+    returnZeroValue = true,
   } = options;
+
+  if (!amount) {
+    if (returnZeroValue) {
+      return "₳0";
+    } else {
+      return "N/A";
+    }
+  }
 
   const formattedAmount = currency(amount, {
     pattern: "!#",
@@ -87,15 +104,23 @@ export const formatUsdAmount = (
     includeCurrencySymbol: true,
     includeEstimateSymbol: false,
     precision: 4,
+    returnZeroValue: true,
   }
 ) => {
-  if (!amount) return "$0";
-
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 4,
+    returnZeroValue = true,
   } = options;
+
+  if (!amount) {
+    if (returnZeroValue) {
+      return "$0";
+    } else {
+      return "N/A";
+    }
+  }
 
   if (precision === 4 && amount < 0.0001 && amount > 0) {
     return "< $0.0001";


### PR DESCRIPTION
Updated:

1. Move loading pop-up window to center of main window like Payment pop-up, specifically so it is also above the upload progress bar.
<img width="1662" height="719" alt="image" src="https://github.com/user-attachments/assets/6e98cc3b-cd68-4d71-9c35-3aef342ebd99" />

2. The option copy in the Release Summary Modal to “Pay with PayPal, Credit, or Debit Card”.

3. Fix NEWM estimated values in the PayPal tab in the Release Summary Modal.
<img width="582" height="484" alt="image" src="https://github.com/user-attachments/assets/8bd26812-809e-4e6e-8267-555d96c3fa0b" />

4. Progress Bar copy during the upload flow to reference PayPal instead of siging a mint transaction.
<img width="1157" height="149" alt="image" src="https://github.com/user-attachments/assets/b537530f-57b4-495f-98d1-81b37e1a19fb" />

