### PR TITLE
[STUD-581][Enhancement]: Implement final Marketplace Tab 'End Sale' copy edits

### DIFF
--- a/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx
@@ -88,8 +88,8 @@ export const ActiveSale: FunctionComponent<ActiveSaleProps> = ({ sale }) => {
 
         { webStudioDisableDistributionAndSales && (
           <Typography fontWeight={ 500 } variant="subtitle1">
-            Please end the sale and we&apos;ll return the unsold Stream Tokens
-            to your wallet.
+            Please end the sale and we&apos;ll move any earnings and unsold
+            Stream Tokens to your wallet.
           </Typography>
         ) }
 
@@ -145,6 +145,7 @@ export const ActiveSale: FunctionComponent<ActiveSaleProps> = ({ sale }) => {
           </>
         ) }
       </Stack>
+
       <EndSaleModal
         handleClose={ () => setIsEndSaleModalOpen(false) }
         handleEndSale={ handleEndSale }

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/EndSaleModal.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/EndSaleModal.tsx
@@ -1,5 +1,8 @@
 import { FunctionComponent } from "react";
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import { Box, Stack, Typography } from "@mui/material";
+
 import { Button, Modal } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 
@@ -18,6 +21,8 @@ export const EndSaleModal: FunctionComponent<EndSaleModalProps> = ({
   isLoading,
   isSoldOut = false,
 }) => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   return (
     <Modal isCloseButtonVisible={ false } isOpen={ isOpen } onClose={ handleClose }>
       <Box
@@ -44,18 +49,25 @@ export const EndSaleModal: FunctionComponent<EndSaleModalProps> = ({
               Are you sure you want to end your stream token sale?
             </Typography>
 
-            { isSoldOut ? (
-              <Typography variant="subtitle2">
-                All earnings from your sold out stream token sale will be moved
-                to your wallet.
-              </Typography>
-            ) : (
-              <Typography variant="subtitle2">
-                The sale will be removed from the Marketplace, and all unsold
-                stream tokens will be returned to the wallet used when creating
-                the sale.
-              </Typography>
-            ) }
+            <Typography variant="subtitle2">
+              { webStudioDisableDistributionAndSales ? (
+                <>
+                  The sale will be removed from the Marketplace. All earnings
+                  and and any unsold stream tokens will be moved to your wallet.
+                </>
+              ) : isSoldOut ? (
+                <>
+                  All earnings from your sold out stream token sale will be
+                  moved to your wallet.
+                </>
+              ) : (
+                <>
+                  The sale will be removed from the Marketplace, and all unsold
+                  stream tokens will be returned to the wallet used when
+                  creating the sale.
+                </>
+              ) }
+            </Typography>
           </Stack>
           <Stack flexDirection="row" gap={ 1 } justifyContent="end" mt={ 1 }>
             <Button

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/EndSaleModal.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/EndSaleModal.tsx
@@ -53,7 +53,7 @@ export const EndSaleModal: FunctionComponent<EndSaleModalProps> = ({
               { webStudioDisableDistributionAndSales ? (
                 <>
                   The sale will be removed from the Marketplace. All earnings
-                  and and any unsold stream tokens will be moved to your wallet.
+                  and any unsold stream tokens will be moved to your wallet.
                 </>
               ) : isSoldOut ? (
                 <>

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/SaleEndPending.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/SaleEndPending.tsx
@@ -1,30 +1,57 @@
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import { AlertTitle, Stack, Typography } from "@mui/material";
+
 import { Alert, HorizontalLine } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 
-const SaleEndPending = () => (
-  <Stack sx={ { gap: 2.5, mt: 1 } }>
-    <Alert>
-      <AlertTitle color={ theme.colors.blue } sx={ { fontWeight: 600 } }>
-        You have a stream token sale for this track that is pending
-        cancellation!
-      </AlertTitle>
-      <Typography
-        color={ theme.colors.blue }
-        fontWeight={ 500 }
-        variant="subtitle1"
-      >
-        Your sale is now being removed from the Marketplace.
+const SaleEndPending = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
+  return (
+    <Stack sx={ { gap: 2.5, mt: 1 } }>
+      <Alert>
+        <AlertTitle color={ theme.colors.blue } sx={ { fontWeight: 600 } }>
+          { webStudioDisableDistributionAndSales ? (
+            <Typography variant="subtitle1">
+              Your stream token sale is being removed from the Marketplace!
+            </Typography>
+          ) : (
+            <>
+              You have a stream token sale for this track that is pending
+              cancellation!
+            </>
+          ) }
+        </AlertTitle>
+
+        { !webStudioDisableDistributionAndSales && (
+          <Typography
+            color={ theme.colors.blue }
+            fontWeight={ 500 }
+            variant="subtitle1"
+          >
+            Your sale is now being removed from the Marketplace.
+          </Typography>
+        ) }
+      </Alert>
+      <Typography mt={ 2.5 } variant="subtitle2">
+        { webStudioDisableDistributionAndSales ? (
+          <>
+            Stream token sales may take several minutes to be removed. You will
+            receive an email notification once the sale has successfully ended.
+          </>
+        ) : (
+          <>
+            Stream token sales may take several minutes to be removed from the
+            Marketplace. You will receive an email notification once the sale
+            has been successfully canceled. Once the cancellation is finalized,
+            you can create a new stream token sale for this track.
+          </>
+        ) }
       </Typography>
-    </Alert>
-    <Typography mt={ 2.5 } variant="subtitle2">
-      Stream token sales may take several minutes to be removed from the
-      Marketplace. You will receive an email notification once the sale has been
-      successfully canceled. Once the cancellation is finalized, you can create
-      a new stream token sale for this track.
-    </Typography>
-    <HorizontalLine />
-  </Stack>
-);
+      <HorizontalLine />
+    </Stack>
+  );
+};
 
 export default SaleEndPending;

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/SaleEndPending.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/SaleEndPending.tsx
@@ -5,33 +5,39 @@ import { AlertTitle, Stack, Typography } from "@mui/material";
 import { Alert, HorizontalLine } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 
+const SunDownAlertTitle = () => (
+  <AlertTitle
+    color={ theme.colors.blue }
+    sx={ { fontWeight: 600, marginBottom: 0 } }
+  >
+    <Typography variant="subtitle1">
+      Your stream token sale is being removed from the Marketplace!
+    </Typography>
+  </AlertTitle>
+);
+
 const SaleEndPending = () => {
   const { webStudioDisableDistributionAndSales } = useFlags();
 
   return (
     <Stack sx={ { gap: 2.5, mt: 1 } }>
       <Alert>
-        <AlertTitle color={ theme.colors.blue } sx={ { fontWeight: 600 } }>
-          { webStudioDisableDistributionAndSales ? (
-            <Typography variant="subtitle1">
-              Your stream token sale is being removed from the Marketplace!
-            </Typography>
-          ) : (
-            <>
+        { webStudioDisableDistributionAndSales ? (
+          <SunDownAlertTitle />
+        ) : (
+          <>
+            <AlertTitle color={ theme.colors.blue } sx={ { fontWeight: 600 } }>
               You have a stream token sale for this track that is pending
               cancellation!
-            </>
-          ) }
-        </AlertTitle>
-
-        { !webStudioDisableDistributionAndSales && (
-          <Typography
-            color={ theme.colors.blue }
-            fontWeight={ 500 }
-            variant="subtitle1"
-          >
-            Your sale is now being removed from the Marketplace.
-          </Typography>
+            </AlertTitle>
+            <Typography
+              color={ theme.colors.blue }
+              fontWeight={ 500 }
+              variant="subtitle1"
+            >
+              Your sale is now being removed from the Marketplace.
+            </Typography>
+          </>
         ) }
       </Alert>
       <Typography mt={ 2.5 } variant="subtitle2">


### PR DESCRIPTION
# Pull Request — Issue [STUD-581](https://projectnewm.atlassian.net/browse/STUD-581)

## Overview

> This PR updates Marketplace end-sale messaging and behavior behind the
> `webStudioDisableDistributionAndSales` feature flag to match the ticket
> requirements.

---

## Files Summary

> **Total Changes:** 3 files  
> _(Counts of added, modified, and deleted files can be seen in the PR diff view.)_

<details>
<summary>Modified (3)</summary>

- **`newm-web/apps/studio/src/pages/home/releases/MarketplaceTab/EndSaleModal.tsx`**
  - — Update confirmation dialog copy under the feature flag.
- **`newm-web/apps/studio/src/pages/home/releases/MarketplaceTab/SaleEndPending.tsx`**
  - — Adjust pending copy for the feature-flagged flow.
- **`newm-web/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx`**
  - — Show the proper controls for the feature-flagged flow.

</details>

---

## Impact

- Updates Marketplace end-sale messaging and flows when
  `webStudioDisableDistributionAndSales` is enabled.
- No behavior changes when the flag is disabled.

---

## Testing

- Not run (copy/UI updates).

---

## Related Issues

- [STUD-581](https://projectnewm.atlassian.net/browse/STUD-581)

---

## Dependencies

- No new dependencies.

---

## Demo

<img width="1361" height="609" alt="STUD-581-active-stream-token-sale-page" src="https://github.com/user-attachments/assets/bf912689-d106-448d-a27b-06e59e1bc8ff" />

<img width="1354" height="602" alt="STUD-581-end-token-sale-approval-dialog" src="https://github.com/user-attachments/assets/cfdc4094-5d49-42a4-89a6-89038f71ef73" />

<img width="1349" height="599" alt="STUD-581-sale-end-pending-page" src="https://github.com/user-attachments/assets/a565809b-217d-43af-b32d-7d2e67a32ec3" />

---

## Additional Notes

- N/A

--END--


[STUD-581]: https://projectnewm.atlassian.net/browse/STUD-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-581]: https://projectnewm.atlassian.net/browse/STUD-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ