### PR TITLE
[Feature][STUD-580]: Gate 'DistributionPricingDialog' when user first interact with the release CTA 'Create New Release'

### DIFF
--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -1,4 +1,5 @@
-import { FunctionComponent, useState } from "react";
+import { FunctionComponent, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { Box, Typography } from "@mui/material";
 
@@ -14,27 +15,66 @@ import { AddSong } from "@newm-web/assets";
 
 import SongList from "./SongList";
 import OfficialStatementCTA from "../../../components/OfficialStatementCTA";
-import { SearchBox } from "../../../components";
+import { DistributionPricingDialog, SearchBox } from "../../../components";
+import { emptyProfile, useGetProfileQuery } from "../../../modules/session";
 import { useGetSongCountQuery } from "../../../modules/song";
 
 const Discography: FunctionComponent = () => {
+  const navigate = useNavigate();
   // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
   const { webStudioAlbumPhaseTwo, webStudioDisableDistributionAndSales } =
     useFlags();
 
+  const {
+    data: {
+      dspPlanSubscribed: isArtistPricePlanSelected = false,
+    } = emptyProfile,
+  } = useGetProfileQuery();
+
   const [query, setQuery] = useState("");
+  const [isPricingDialogOpen, setIsPricingDialogOpen] = useState(false);
 
   const { data: { count: totalCountOfSongs = 0 } = {} } = useGetSongCountQuery({
     ownerIds: ["me"],
     phrase: query,
   });
 
+  const shouldGatePricingDialog = useMemo(() => {
+    return webStudioAlbumPhaseTwo && !isArtistPricePlanSelected;
+  }, [isArtistPricePlanSelected, webStudioAlbumPhaseTwo]);
+
   const handleSearch = (searched: string) => {
     setQuery(searched);
   };
 
+  const handleCreateReleaseClick = (
+    event: React.MouseEvent<HTMLAnchorElement>
+  ) => {
+    if (!webStudioAlbumPhaseTwo) return;
+    if (!shouldGatePricingDialog) return;
+    event.preventDefault();
+    setIsPricingDialogOpen(true);
+  };
+
+  const handlePricingDialogCancel = () => {
+    setIsPricingDialogOpen(false);
+  };
+
+  const handlePricingDialogConfirm = () => {
+    setIsPricingDialogOpen(false);
+    navigate("/home/releases/new");
+  };
+
   return (
     <>
+      { webStudioAlbumPhaseTwo && !isArtistPricePlanSelected && (
+        <DistributionPricingDialog
+          open={ isPricingDialogOpen }
+          onCancel={ handlePricingDialogCancel }
+          onConfirm={ handlePricingDialogConfirm }
+        />
+      ) }
+
       <Typography sx={ { pb: 4 } } variant="h3">
         RELEASES
       </Typography>
@@ -66,6 +106,7 @@ const Discography: FunctionComponent = () => {
                 ? "/home/releases/new"
                 : "/home/upload-song"
             }
+            onClick={ handleCreateReleaseClick }
           >
             <GradientDashedOutline sx={ { padding: 3 } }>
               <IconMessage icon={ <AddSong /> } message="Create New Release" />

--- a/apps/studio/src/pages/home/releases/Releases.tsx
+++ b/apps/studio/src/pages/home/releases/Releases.tsx
@@ -13,12 +13,24 @@ import TrackDetailsRouter from "./release/tracks/TrackDetailsRouter";
 import Distribute from "./release/distribute/Distribute";
 import NewTrack from "./release/tracks/NewTrack";
 import NotFoundPage from "../../NotFoundPage";
+import { emptyProfile, useGetProfileQuery } from "../../../modules/session";
 
 const Releases: FunctionComponent = () => {
   // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
   // TODO(webStudioDisableDistributionAndSales): Remove once flag is retired.
   const { webStudioAlbumPhaseTwo, webStudioDisableDistributionAndSales } =
     useFlags();
+
+  const {
+    data: {
+      dspPlanSubscribed: isArtistPricePlanSelected = false,
+    } = emptyProfile,
+  } = useGetProfileQuery();
+
+  const shouldBlockReleaseCreation =
+    webStudioAlbumPhaseTwo &&
+    !webStudioDisableDistributionAndSales &&
+    !isArtistPricePlanSelected;
 
   return (
     <Container
@@ -46,6 +58,8 @@ const Releases: FunctionComponent = () => {
               element={
                 webStudioDisableDistributionAndSales ? (
                   <Navigate to="/home/releases" replace />
+                ) : shouldBlockReleaseCreation ? (
+                  <Navigate to="/home/releases" replace />
                 ) : (
                   <ReleaseDetails />
                 )
@@ -57,6 +71,8 @@ const Releases: FunctionComponent = () => {
             <Route
               element={
                 webStudioDisableDistributionAndSales ? (
+                  <Navigate to="/home/releases" replace />
+                ) : shouldBlockReleaseCreation ? (
                   <Navigate to="/home/releases" replace />
                 ) : (
                   <NewTrack />

--- a/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx
@@ -1,8 +1,6 @@
-import { FunctionComponent, useEffect, useRef, useState } from "react";
+import { FunctionComponent, useEffect, useRef } from "react";
 
 import { useFormikContext } from "formik";
-
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 import { Box, Link, Stack, Typography, useTheme } from "@mui/material";
 
@@ -24,17 +22,13 @@ import {
   NEWM_STUDIO_FAQ_URL,
   SONG_DESCRIPTION_MAX_CHARACTER_COUNT,
 } from "../../../../../common";
-import { DistributionPricingDialog, PlaySong } from "../../../../../components";
+import { PlaySong } from "../../../../../components";
 import SelectCoCreators from "../../../../../components/minting/SelectCoCreators";
 import {
   useGetGenresQuery,
   useGetLanguagesQuery,
   useGetMoodsQuery,
 } from "../../../../../modules/content";
-import {
-  emptyProfile,
-  useGetProfileQuery,
-} from "../../../../../modules/session";
 import { Creditor, Featured, Owner } from "../../../../../modules/song";
 
 interface BasicTrackDetailsProps {
@@ -49,16 +43,6 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
   trackId = "",
 }) => {
   const theme = useTheme();
-  const {
-    data: {
-      dspPlanSubscribed: isArtistPricePlanSelected = false,
-    } = emptyProfile,
-  } = useGetProfileQuery();
-  const {
-    webStudioAlbumPhaseTwo,
-    webStudioDisableTrackDistributionAndMinting,
-  } = useFlags();
-
   const { data: genres = [] } = useGetGenresQuery();
   const { data: moodOptions = [] } = useGetMoodsQuery();
   const { data: languages = [] } = useGetLanguagesQuery();
@@ -79,24 +63,6 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
     isSubmitting,
     initialValues,
   } = useFormikContext<TrackFormValues>();
-
-  // DSP pricing plan mint song toggling
-  const [isPricingPlansOpen, setIsPricingPlansOpen] = useState(false);
-  const handlePricingPlanCancel = () => {
-    setIsPricingPlansOpen(false);
-    setFieldValue("isMinting", false);
-  };
-  const handlePricingPlanConfirm = () => {
-    setIsPricingPlansOpen(false);
-    setFieldValue("isMinting", true);
-  };
-
-  // Monitor feature flag changes, particularly seen for pricing plan acceptance
-  useEffect(() => {
-    if (webStudioDisableTrackDistributionAndMinting) {
-      setFieldValue("isMinting", false);
-    }
-  }, [webStudioDisableTrackDistributionAndMinting, setFieldValue]);
 
   const hasCoverArtChanged = values.coverArtUrl !== initialValues.coverArtUrl;
 
@@ -141,13 +107,6 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
 
   return (
     <Stack>
-      { !webStudioAlbumPhaseTwo && !isArtistPricePlanSelected && (
-        <DistributionPricingDialog
-          open={ isPricingPlansOpen }
-          onCancel={ handlePricingPlanCancel }
-          onConfirm={ handlePricingPlanConfirm }
-        />
-      ) }
       <Stack direction="column" spacing={ 3 }>
         <Stack
           sx={ {

--- a/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx
@@ -54,7 +54,11 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
       dspPlanSubscribed: isArtistPricePlanSelected = false,
     } = emptyProfile,
   } = useGetProfileQuery();
-  const { webStudioDisableTrackDistributionAndMinting } = useFlags();
+  const {
+    webStudioAlbumPhaseTwo,
+    webStudioDisableTrackDistributionAndMinting,
+  } = useFlags();
+
   const { data: genres = [] } = useGetGenresQuery();
   const { data: moodOptions = [] } = useGetMoodsQuery();
   const { data: languages = [] } = useGetLanguagesQuery();
@@ -137,7 +141,7 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
 
   return (
     <Stack>
-      { !isArtistPricePlanSelected && (
+      { !webStudioAlbumPhaseTwo && !isArtistPricePlanSelected && (
         <DistributionPricingDialog
           open={ isPricingPlansOpen }
           onCancel={ handlePricingPlanCancel }

--- a/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -86,13 +86,9 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
   const songDetailsRef = useRef<HTMLDivElement>(null);
 
   const {
-    // webStudioAlbumPhaseTwo,
     webStudioDisableTrackDistributionAndMinting,
-    // webStudioDisableDistributionAndSales,
+    webStudioDisableDistributionAndSales,
   } = useFlags();
-
-  const webStudioDisableDistributionAndSales = false;
-  const webStudioAlbumPhaseTwo = false;
 
   const isDistributionDisabled =
     webStudioDisableDistributionAndSales ||
@@ -214,7 +210,7 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
 
   return (
     <Stack>
-      { !webStudioAlbumPhaseTwo && !isArtistPricePlanSelected && (
+      { !isArtistPricePlanSelected && (
         <DistributionPricingDialog
           open={ isPricingPlansOpen }
           onCancel={ handlePricingPlanCancel }
@@ -447,7 +443,7 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
                   title="DISTRIBUTE & MINT SONG"
                   toggleTooltipText={ tooltipContent }
                   onClick={ () => {
-                    if (!webStudioAlbumPhaseTwo && !isArtistPricePlanSelected) {
+                    if (!isArtistPricePlanSelected) {
                       handlePricingPlanOpen();
                     }
                   } }

--- a/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -86,9 +86,13 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
   const songDetailsRef = useRef<HTMLDivElement>(null);
 
   const {
+    // webStudioAlbumPhaseTwo,
     webStudioDisableTrackDistributionAndMinting,
-    webStudioDisableDistributionAndSales,
+    // webStudioDisableDistributionAndSales,
   } = useFlags();
+
+  const webStudioDisableDistributionAndSales = false;
+  const webStudioAlbumPhaseTwo = false;
 
   const isDistributionDisabled =
     webStudioDisableDistributionAndSales ||
@@ -210,7 +214,7 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
 
   return (
     <Stack>
-      { !isArtistPricePlanSelected && (
+      { !webStudioAlbumPhaseTwo && !isArtistPricePlanSelected && (
         <DistributionPricingDialog
           open={ isPricingPlansOpen }
           onCancel={ handlePricingPlanCancel }
@@ -443,7 +447,9 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
                   title="DISTRIBUTE & MINT SONG"
                   toggleTooltipText={ tooltipContent }
                   onClick={ () => {
-                    if (!isArtistPricePlanSelected) handlePricingPlanOpen();
+                    if (!webStudioAlbumPhaseTwo && !isArtistPricePlanSelected) {
+                      handlePricingPlanOpen();
+                    }
                   } }
                 />
 


### PR DESCRIPTION
# Pull Request — Issue [STUD-580](https://projectnewm.atlassian.net/browse/STUD-580)

## Overview

Move the DistributionPricingDialog flow to the Releases CTA for Phase Two. The dialog now appears on first interaction with the CTA when the user is not subscribed, and routes to the correct creation flow after acceptance. Phase One behavior remains unchanged.

---

## Files Summary

> **Total Changes:** 4 files modified

<details>
<summary>Modified (4)</summary>

- **`newm-web/apps/studio/src/pages/home/releases/Discography.tsx`**
  - Adds CTA gating and renders `DistributionPricingDialog` for Phase Two only.
- **`newm-web/apps/studio/src/pages/home/releases/Releases.tsx`**
  - Guards `/home/releases/new` and `/home/releases/new/track/new` based on flags and DSP subscription; routes to `/home/upload-song` when Phase Two is off.
- **`newm-web/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx`**
  - Keeps the legacy dialog flow only when Phase Two is off; allows mint toggle without dialog for Phase Two.
- **`newm-web/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx`**
  - Mirrors BasicSongDetails behavior for Phase Two gating.

</details>

## Impact

- Phase Two: CTA shows pricing dialog before routing to `/home/releases/new` when user is not subscribed.
- Phase Two: direct navigation to `/home/releases/new` is blocked unless subscribed.
- Phase One: legacy upload-song flow remains; dialog behavior in BasicSongDetails/BasicTrackDetails is unchanged.

---

## Testing

- Not run (UI flow changes).

---

## Related Issues

- STUD-580

---

## Dependencies

- No new dependencies.

---

## Demo

https://github.com/user-attachments/assets/a1360089-9e0e-4c28-80f4-e6b2447e98ab

---

## Additional Notes

- Flag behavior recap:
  - `webStudioDisableDistributionAndSales=true` keeps users in `/home/releases`.
  - `webStudioAlbumPhaseTwo=false` routes creation to `/home/upload-song` and uses legacy dialog flow.
  - `webStudioAlbumPhaseTwo=true` uses the new CTA dialog gating and `/home/releases/new` flow.

--END--

[STUD-580]: https://projectnewm.atlassian.net/browse/STUD-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ