### PR TITLE
[STUD-507][Enhancement]: Update tooltip copy within the distribution user flow -- follow-up

### DIFF
--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -13,6 +13,7 @@ export const NEWM_STUDIO_OFFICIAL_STATEMENT_URL = `${NEWM_IO_URL}sunset/`;
 export const NEWM_STUDIO_DISCORD_URL =
   "https://discord.com/channels/931903540056694856/1153293933468713041";
 export const NEWM_STUDIO_FAQ_URL = "https://newm.io/artist-faq";
+export const NEWM_STUDIO_COPYRIGHT_FAQ_URL = `${NEWM_STUDIO_FAQ_URL}/#copyrights`;
 export const NEWM_STUDIO_TELEGRAM_URL = "https://t.me/NEWMartists";
 export const NEWM_STUDIO_OUTLETS_URL = "https://newm.io/artist-faq/#outlets";
 export const NEWM_PRIVACY_POLICY_URL = "https://newm.io/privacy-policy/";
@@ -62,3 +63,23 @@ export const SALE_COMPLETE_UPDATED_EVENT = "saleCompleteUpdated";
  * Stream token sale default bundle amount
  */
 export const SALE_DEFAULT_BUNDLE_AMOUNT = 1;
+
+export const FIELDS_TOOLTIP_COPY_TEXT = {
+  instrumental: `Tracks without vocals or lyrics should be indicated as an instrumental.
+   Failure to accurately label the track could result in a declined distribution submission.`,
+
+  originalReleaseDate: `If your release has already been distributed on other platforms,
+     you may input the original release date here, but it's not required.`,
+
+  releaseCodeNumber: `A release code number is a unique code that identifies your release.
+   If you do not already have one, leave this field blank,
+    and a new release code number will be auto-generated for you.`,
+
+  releaseCodeType: `If you already have a release code, 
+  select the code type here and enter the code in the next field. If not, 
+  leave this field blank and a new release code will be auto-generated for you.`,
+
+  releaseDate: `When setting a release date, remember to factor in approval
+    from any collaborators and/or featured artists, as well as quality assurance checks,
+    which can take up to 15 days.`,
+} as const;

--- a/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
@@ -34,7 +34,11 @@ import {
   type RequestNavigationOptions,
   useUnsavedChanges,
 } from "../../../../contexts/UnsavedChangesContext";
-import { NONE_OPTION, commonYupValidation } from "../../../../common";
+import {
+  FIELDS_TOOLTIP_COPY_TEXT,
+  NONE_OPTION,
+  commonYupValidation,
+} from "../../../../common";
 import { emptyProfile, useGetProfileQuery } from "../../../../modules/session";
 import ReleaseDeletionHelp from "../ReleaseDeletionHelp";
 
@@ -289,7 +293,7 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
                       name="releaseDate"
                       placeholder="Select date"
                       ref={ releaseDateRef as React.Ref<HTMLInputElement> }
-                      tooltipText="TO BE UPDATED"
+                      tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.releaseDate }
                       type="date"
                     />
                     <TextInputField
@@ -298,7 +302,7 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
                       max={ new Date().toISOString().split("T")[0] }
                       name="originalReleaseDate"
                       placeholder="Select date"
-                      tooltipText="TO BE UPDATED"
+                      tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.originalReleaseDate }
                       type="date"
                     />
                     <DropdownSelectField
@@ -307,7 +311,7 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
                       name="releaseCodeType"
                       options={ [...RELEASE_CODE_TYPE_OPTIONS] }
                       placeholder="Select one"
-                      tooltipText="TO BE UPDATED"
+                      tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.releaseCodeType }
                     />
                     <TextInputField
                       disabled={
@@ -318,7 +322,7 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
                       label="RELEASE CODE NUMBER"
                       name="releaseCodeNumber"
                       placeholder="000000000000"
-                      tooltipText="TO BE UPDATED"
+                      tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.releaseCodeNumber }
                     />
                   </Stack>
 

--- a/apps/studio/src/pages/home/releases/release/tracks/AdvancedTrackDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/AdvancedTrackDetails.tsx
@@ -21,8 +21,9 @@ import {
   useGetSongQuery,
 } from "../../../../../modules/song";
 import {
+  FIELDS_TOOLTIP_COPY_TEXT,
   MIN_DISTRIBUTION_TIME,
-  NEWM_STUDIO_FAQ_URL,
+  NEWM_STUDIO_COPYRIGHT_FAQ_URL,
   NONE_OPTION,
 } from "../../../../../common";
 import {
@@ -30,6 +31,9 @@ import {
   useGetProfileQuery,
 } from "../../../../../modules/session";
 import { CoverRemixSample } from "../../../../../components";
+
+// TODO: fields such as 'schedule release date', 'original publication date'?, 'release code **', and 'IPI'
+// TODO: will be removed from the track details page as part of phase 2.
 
 const AdvancedTrackDetails = () => {
   const { data: { firstName } = emptyProfile } = useGetProfileQuery();
@@ -132,11 +136,7 @@ const AdvancedTrackDetails = () => {
       <SwitchInputField
         name="isInstrumental"
         title="Is this song an instrumental?"
-        tooltipText={
-          "Songs without voices or lyrics should be indicated as an " +
-          "instrumental. Failure to accurately label the song will " +
-          "result in a declined distribution submission."
-        }
+        tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.instrumental }
       />
       <SwitchInputField
         name="isExplicit"
@@ -192,9 +192,9 @@ const AdvancedTrackDetails = () => {
               The copyright for a musical composition covers the music and
               lyrics of a song (not the recorded performance). It is typically
               owned by the songwriter and/or music publisher. If you are not the
-              copyright holder of the song composition, please review{ " " }
+              copyright holder of the track composition, please review{ " " }
               <Link
-                href={ NEWM_STUDIO_FAQ_URL }
+                href={ NEWM_STUDIO_COPYRIGHT_FAQ_URL }
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -214,11 +214,11 @@ const AdvancedTrackDetails = () => {
           tooltipText={
             <span>
               The copyright in a sound recording covers the recording itself (it
-              does not cover the music or lyrics of the song). It is typically
+              does not cover the music or lyrics of the track). It is typically
               owned by the artist and/or record label. If you are not the
               copyright holder of the sound recording, please review{ " " }
               <Link
-                href={ NEWM_STUDIO_FAQ_URL }
+                href={ NEWM_STUDIO_COPYRIGHT_FAQ_URL }
                 rel="noopener noreferrer"
                 target="_blank"
               >


### PR DESCRIPTION
# Pull Request — Issue [STUD-507](https://projectnewm.atlassian.net/browse/STUD-507)

## Overview

This PR centralizes and updates release/track tooltip copy in shared constants and replaces placeholder text in release details. It also aligns track copyright tooltip wording and links to the dedicated copyright FAQ anchor.

**Clarification**: for track-related fields in `AdvancedTrackDetails` that need inline links, we can keep the JSX inline as-is, or consider a React-node constants map. Adding the copy to shared constants and splitting strings at render time is possible but is not the ideal approach.

---

## Files Summary

**Total Changes:** 3 files  

<details>
<summary>Modified (3)</summary>

- **`apps/studio/src/common/constants.ts`**
  - Added shared tooltip copy constants and a copyright FAQ URL.
- **`apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx`**
  - Replaced placeholder tooltips with shared constants.
- **`apps/studio/src/pages/home/releases/release/tracks/AdvancedTrackDetails.tsx`**
  - Reused shared tooltip copy, refined wording, and switched FAQ link.

</details>

---

## Impact

- Tooltip copy is now consistent across release and track forms.
- Release details fields no longer show placeholder text.
- Copyright tooltips now link directly to the copyright FAQ section.

---

## Testing

- Not run (copy updates only).

---

## Related Issues

- Closes [STUD-507](https://projectnewm.atlassian.net/browse/STUD-507)

---

## Dependencies

- No new dependencies.

---

## Additional Notes

- Follow-up work may remove some advanced track fields in phase 2 (existing TODOs).

--END--


[STUD-507]: https://projectnewm.atlassian.net/browse/STUD-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-507]: https://projectnewm.atlassian.net/browse/STUD-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ