### PR TITLE
feat(studio/releases):Phase 2 release/track UI updates + notes

### DIFF
--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -64,6 +64,7 @@ export const SALE_COMPLETE_UPDATED_EVENT = "saleCompleteUpdated";
  */
 export const SALE_DEFAULT_BUNDLE_AMOUNT = 1;
 
+// * KEPT FOR BACKWARDS COMPATIBILITY --- REMOVE ONCE FULLY MIGRATED TO RELEASES & TRACKS.
 export const FIELDS_TOOLTIP_COPY_TEXT = {
   instrumental: `Tracks without vocals or lyrics should be indicated as an instrumental.
    Failure to accurately label the track could result in a declined distribution submission.`,

--- a/apps/studio/src/components/minting/CoverRemixSample.tsx
+++ b/apps/studio/src/components/minting/CoverRemixSample.tsx
@@ -19,7 +19,7 @@ export const CoverRemixSample: FunctionComponent<CoverRemixSampleProps> = ({
       disabled={ disabled }
       name="isCoverRemixSample"
       title={
-        "Is this song a cover, remix, mixtape, mashup, " +
+        "Is this track a cover, remix, mixtape, mashup, " +
         "or contain samples and/or any part of the intellectual property of another work?"
       }
     >

--- a/apps/studio/src/modules/releases/index.ts
+++ b/apps/studio/src/modules/releases/index.ts
@@ -1,0 +1,2 @@
+export * from "./release";
+export * from "./track";

--- a/apps/studio/src/modules/releases/release/index.ts
+++ b/apps/studio/src/modules/releases/release/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/apps/studio/src/modules/releases/release/types.ts
+++ b/apps/studio/src/modules/releases/release/types.ts
@@ -1,0 +1,25 @@
+// * Tentative type definition for releases.
+// eslint-disable-next-line max-len
+// * based on: https://github.com/projectNEWM/newm-server/blob/master/newm-server/src/main/kotlin/io/newm/server/features/song/model/Release.kt
+
+import { MintingStatus } from "@newm-web/types";
+
+export interface Release {
+  readonly archived?: boolean | null;
+  readonly barcodeNumber?: string | null;
+  readonly barcodeType?: string | null;
+  readonly coverArtUrl?: string | null;
+  readonly createdAt?: string | null;
+  readonly errorMessage?: string | null;
+  readonly genres?: string[] | null;
+  readonly hasSubmittedForDistribution?: boolean | null;
+  readonly id: string;
+  readonly locked?: boolean | null;
+  readonly mintingStatus?: MintingStatus | null;
+  readonly ownerId?: string | null;
+  readonly publicationDate?: string | null;
+  readonly releaseDate?: string | null;
+  readonly releaseType?: string | null;
+  readonly title?: string | null;
+  readonly totalTracksLength?: number | null;
+}

--- a/apps/studio/src/modules/releases/track/index.ts
+++ b/apps/studio/src/modules/releases/track/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/apps/studio/src/modules/releases/track/types.ts
+++ b/apps/studio/src/modules/releases/track/types.ts
@@ -1,0 +1,44 @@
+// * Tentative type definition for tracks.
+// TODO: to be updated with the final track type.
+
+import { MarketplaceStatus, MintingStatus, PaymentType } from "@newm-web/types";
+
+export interface Track {
+  readonly album?: string;
+  readonly archived: boolean;
+  readonly barcodeNumber?: string;
+  readonly barcodeType?: string;
+  readonly compositionCopyrightOwner: string;
+  readonly compositionCopyrightYear: string;
+  readonly coverArtUrl?: string;
+  readonly coverRemixSample?: boolean;
+  readonly createdAt: string;
+  readonly description?: string;
+  readonly duration?: number;
+  readonly earnings?: number;
+  readonly genres: ReadonlyArray<string>;
+  readonly id: string;
+  readonly instrumental?: boolean;
+  readonly ipis?: ReadonlyArray<string>;
+  readonly isrc?: string;
+  readonly iswc?: string;
+  readonly language?: string;
+  readonly lyricsUrl?: string;
+  readonly marketplaceStatus: MarketplaceStatus;
+  readonly mintCost?: number;
+  readonly mintPaymentType?: PaymentType;
+  readonly mintingStatus: MintingStatus;
+  readonly moods?: ReadonlyArray<string>;
+  readonly nftName?: string;
+  readonly nftPolicyId?: string;
+  readonly ownerId: string;
+  readonly parentalAdvisory?: string;
+  readonly phonographicCopyrightOwner: string;
+  readonly phonographicCopyrightYear: string;
+  readonly price?: string;
+  readonly publicationDate?: string;
+  readonly releaseDate?: string;
+  readonly streamUrl?: string;
+  readonly title: string;
+  readonly track?: number;
+}

--- a/apps/studio/src/pages/home/releases/README.md
+++ b/apps/studio/src/pages/home/releases/README.md
@@ -1,0 +1,54 @@
+# Releases (Studio) - Phase 2 Notes
+
+This folder contains the updated release flow UI for album and single-track work.
+The frontend changes are ahead of backend support, so a few pieces are intentionally
+left in a transitional state to keep the app compiling.
+
+## Missing or Pending Work
+
+- **Backend models + endpoints**
+
+  - Await final release/track models, enums, and REST endpoints from the backend.
+  - Once shipped, wire them into the Studio API layer and update payload shapes.
+
+- **Release flow property renames**
+
+  - Multiple release properties still use interim names until the final release type
+    is confirmed. Update the release details, list, and distribution payload mapping
+    once the backend schema is finalized.
+  - Primary files: `ReleaseDetails.tsx`, `ReleaseList.tsx`, `Releases.tsx`,
+    `release/distribute/*`.
+
+- **Track flow property renames**
+
+  - Track-level fields are pending the final track schema and are still mapped with
+    interim names. Update the form types and API mapping once final field names land.
+  - Primary files: `release/tracks/*`, `release/tracks/trackFormTypes.ts`.
+
+- **Remove legacy "song" files**
+
+  - Legacy "song" files within this folder will be removed (tracked in Jira).
+  - Keep the migration focused inside `release/tracks/**` once backend models land.
+
+- **Create release + track thunks**
+
+  - Implement CRUD thunks for releases and tracks with the new backend endpoints.
+  - Replace any placeholder/legacy calls still using "song" thunks.
+
+- **Add delete trigger components**
+  - Build `DeleteReleaseTrigger` and `DeleteTrackTrigger` components.
+  - Each trigger should render the delete button and open the confirm modal.
+  - Requires backend support for a `locked` (or similar) field to determine whether
+    a release or track can be deleted.
+
+## Notes for the Next Pass
+
+- Keep property renames scoped to `release/tracks/**` after the backend models land.
+- Revisit types and payload mappers once release and track schemas are final.
+
+## Cleanup (Later Pass)
+
+- Remove the entire `library/` directory and its files.
+- Remove `releases/MarketplaceTab` once it is replaced by the new flow.
+- Remove release-related legacy "song" files under `releases/**`.
+- Remove song-related types and thunks outside of `releases/`.

--- a/apps/studio/src/pages/home/releases/ReleaseList.tsx
+++ b/apps/studio/src/pages/home/releases/ReleaseList.tsx
@@ -34,34 +34,11 @@ import NoSongsYet from "./NoSongsYet";
 import { ErrorOccurredMintingStatuses, MintingStatus } from "./MintingStatus";
 import TableHead from "./Table/TableHead";
 import ReleaseDeletionHelp from "./ReleaseDeletionHelp";
+import { Release } from "../../../modules/releases";
 import { convertMillisecondsToSongFormat } from "../../../modules/song";
 import { NEWM_SUPPORT_LINK } from "../../../common";
 
 // ! DO NOT USE IN PRODUCTION YET <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-// * Tentative type definition for releases.
-// eslint-disable-next-line max-len
-// * based on: https://github.com/projectNEWM/newm-server/blob/master/newm-server/src/main/kotlin/io/newm/server/features/song/model/Release.kt
-// TODO: Move to a shared types file once we have the real data.
-export interface Release {
-  archived?: boolean | null;
-  barcodeNumber?: string | null;
-  barcodeType?: string | null;
-  coverArtUrl?: string | null;
-  createdAt?: string | null;
-  errorMessage?: string | null;
-  genres?: string[] | null;
-  hasSubmittedForDistribution?: boolean | null;
-  id: string;
-  locked?: boolean | null;
-  mintingStatus?: MintingStatusType | null;
-  ownerId?: string | null;
-  publicationDate?: string | null;
-  releaseDate?: string | null;
-  releaseType?: string | null;
-  title?: string | null;
-  totalTracksLength?: number | null;
-}
 
 interface ReleaseListProps {
   query: string;

--- a/apps/studio/src/pages/home/releases/constants.tsx
+++ b/apps/studio/src/pages/home/releases/constants.tsx
@@ -1,0 +1,61 @@
+import { Link } from "@mui/material";
+
+import { NEWM_STUDIO_COPYRIGHT_FAQ_URL } from "../../../common/constants";
+
+export const FIELDS_TOOLTIP_COPY_TEXT = {
+  explicit: `Explicit content includes strong or discriminatory language,
+    "or depictions of sex, violence or substance abuse.`,
+
+  instrumental: `Tracks without vocals or lyrics should be indicated as an instrumental.
+     Failure to accurately label the track could result in a declined distribution submission.`,
+
+  originalReleaseDate: `If your release has already been distributed on other platforms,
+       you may input the original release date here, but it's not required.`,
+
+  releaseCodeNumber: `A release code number is a unique code that identifies your release.
+     If you do not already have one, leave this field blank,
+      and a new release code number will be auto-generated for you.`,
+
+  releaseCodeType: `If you already have a release code, 
+    select the code type here and enter the code in the next field. If not, 
+    leave this field blank and a new release code will be auto-generated for you.`,
+
+  releaseDate: `When setting a release date, remember to factor in approval
+      from any collaborators and/or featured artists, as well as quality assurance checks,
+      which can take up to 15 days.`,
+} as const;
+
+export const FIELDS_TOOLTIP_COPY_NODE = {
+  compositionCopyright: (
+    <span>
+      The copyright for a musical composition covers the music and lyrics of a
+      track (not the recorded performance). It is typically owned by the
+      songwriter and/or music publisher. If you are not the copyright holder of
+      the track composition, please review{ " " }
+      <Link
+        href={ NEWM_STUDIO_COPYRIGHT_FAQ_URL }
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        copyright requirements
+      </Link>{ " " }
+      in our FAQ.
+    </span>
+  ),
+  phonographicCopyright: (
+    <span>
+      The copyright in a sound recording covers the recording itself (it does
+      not cover the music or lyrics of the track). It is typically owned by the
+      artist and/or record label. If you are not the copyright holder of the
+      sound recording, please review{ " " }
+      <Link
+        href={ NEWM_STUDIO_COPYRIGHT_FAQ_URL }
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        copyright requirements
+      </Link>{ " " }
+      in our FAQ.
+    </span>
+  ),
+} as const;

--- a/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
@@ -13,7 +13,6 @@ import * as Yup from "yup";
 
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import DeleteIcon from "@mui/icons-material/Delete";
-import LockIcon from "@mui/icons-material/Lock";
 import { AddOutlined } from "@mui/icons-material";
 import { Box, Stack, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
@@ -43,6 +42,13 @@ import { emptyProfile, useGetProfileQuery } from "../../../../modules/session";
 import ReleaseDeletionHelp from "../ReleaseDeletionHelp";
 
 const RELEASE_CODE_TYPE_OPTIONS = [NONE_OPTION, "EAN", "UPC", "JAN"] as const;
+const RELEASE_TYPE_OPTIONS = [
+  NONE_OPTION,
+  "Album",
+  "Single",
+  "EP",
+  "Compilation",
+] as const;
 
 const REQUIRED_FIELDS = {
   coverArtUrl: true,
@@ -373,30 +379,21 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
                       flexDirection: ["column", "column", "row"],
                     } }
                   >
+                    <DropdownSelectField
+                      isOptional={ false }
+                      label="RELEASE TYPE"
+                      name="releaseType"
+                      options={ [...RELEASE_TYPE_OPTIONS] }
+                      placeholder="Select one"
+                      tooltipText="TO BE UPDATED"
+                    />
+
                     <TextInputField
                       isOptional={ false }
                       label="RELEASE TITLE"
                       name="releaseTitle"
                       placeholder="Give your release a title"
                       ref={ releaseTitleRef as React.Ref<HTMLInputElement> }
-                    />
-
-                    <TextInputField
-                      disabled={ true }
-                      isOptional={ false }
-                      label="ARTIST NAME"
-                      name="artistName"
-                      startAdornment={
-                        <LockIcon
-                          sx={ {
-                            color: theme.colors.white,
-                            height: "auto",
-                            marginLeft: 1,
-                            marginRight: 1,
-                            width: 22,
-                          } }
-                        />
-                      }
                     />
                   </Stack>
                 </Box>
@@ -408,7 +405,7 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
                     TRACKS
                   </Typography>
 
-                  <Box sx={ { padding: 2 } }>Track list (placeholder)</Box>
+                  <Box sx={ { padding: 2 } }>Track list - Coming Soon!</Box>
 
                   <Box
                     sx={ {

--- a/apps/studio/src/pages/home/releases/release/tracks/AdvancedTrackDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/AdvancedTrackDetails.tsx
@@ -3,46 +3,44 @@ import { useParams } from "react-router-dom";
 
 import { useFormikContext } from "formik";
 
-import { Link, Stack } from "@mui/material";
+import { Box, Stack, useTheme } from "@mui/material";
 
 import { isValueInArray, scrollToError } from "@newm-web/utils";
 import {
   CopyrightInputField,
-  DropdownSelectField,
+  ErrorMessage,
+  HorizontalLine,
   SwitchInputField,
   TextInputField,
 } from "@newm-web/elements";
 import { MintingStatus } from "@newm-web/types";
 
+import SelectCoCreators from "../../../../../components/minting/SelectCoCreators";
 import {
+  Creditor,
+  Featured,
+  Owner,
   UploadSongThunkRequest,
   emptySong,
-  useGetEarliestReleaseDateQuery,
   useGetSongQuery,
 } from "../../../../../modules/song";
-import {
-  FIELDS_TOOLTIP_COPY_TEXT,
-  MIN_DISTRIBUTION_TIME,
-  NEWM_STUDIO_COPYRIGHT_FAQ_URL,
-  NONE_OPTION,
-} from "../../../../../common";
-import {
-  emptyProfile,
-  useGetProfileQuery,
-} from "../../../../../modules/session";
+import { NONE_OPTION } from "../../../../../common";
 import { CoverRemixSample } from "../../../../../components";
-
-// TODO: fields such as 'schedule release date', 'original publication date'?, 'release code **', and 'IPI'
-// TODO: will be removed from the track details page as part of phase 2.
+import {
+  FIELDS_TOOLTIP_COPY_NODE,
+  FIELDS_TOOLTIP_COPY_TEXT,
+} from "../../constants";
 
 const AdvancedTrackDetails = () => {
-  const { data: { firstName } = emptyProfile } = useGetProfileQuery();
+  const theme = useTheme();
   const { trackId } = useParams<"trackId">();
-  const { data: song = emptySong } = useGetSongQuery(trackId as string, {
+
+  // TODO: Replace with useGetTrackQuery once API is updated.
+  const { data: track = emptySong } = useGetSongQuery(trackId as string, {
     skip: !trackId,
   });
 
-  const isDeclined = song.mintingStatus === MintingStatus.Declined;
+  const isDeclined = track.mintingStatus === MintingStatus.Declined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isrcRef = useRef<any>(null);
@@ -51,24 +49,12 @@ const AdvancedTrackDetails = () => {
   const releaseDateRef = useRef<HTMLInputElement | null>(null);
   const compositionCopyrightRef = useRef<HTMLDivElement | null>(null);
   const phonographicCopyrightRef = useRef<HTMLDivElement | null>(null);
+  const coCreatorsRef = useRef<HTMLDivElement | null>(null);
   const ipiRef = useRef<HTMLInputElement | null>(null);
   const iswcRef = useRef<HTMLInputElement | null>(null);
 
-  const { isSubmitting, setFieldValue, errors, values } =
+  const { isSubmitting, setFieldValue, errors, touched, values } =
     useFormikContext<UploadSongThunkRequest>();
-
-  const { data: { date: earliestReleaseDate } = {} } =
-    useGetEarliestReleaseDateQuery(undefined, {
-      // endpoint throws error if user hasn't added first name
-      skip: !firstName,
-    });
-
-  // Minimum date for schedule release date picker when no earliest release date
-  const minDistributionDate = new Date(
-    Date.now() + MIN_DISTRIBUTION_TIME * 24 * 60 * 60 * 1000
-  )
-    .toISOString()
-    .split("T")[0];
 
   useEffect(() => {
     if (values.barcodeType === NONE_OPTION || values.barcodeType === "") {
@@ -124,8 +110,22 @@ const AdvancedTrackDetails = () => {
         element: iswcRef.current,
         error: errors.iswc,
       },
+      { element: coCreatorsRef.current, error: errors.creditors },
+      { element: coCreatorsRef.current, error: errors.owners },
     ]);
   }, [errors, isSubmitting, isrcRef]);
+
+  const handleChangeOwners = (owners: ReadonlyArray<Owner>) => {
+    setFieldValue("owners", owners);
+  };
+
+  const handleChangeCreditors = (creditors: ReadonlyArray<Creditor>) => {
+    setFieldValue("creditors", creditors);
+  };
+
+  const handleChangeFeatured = (featured: ReadonlyArray<Featured>) => {
+    setFieldValue("featured", featured);
+  };
 
   return (
     <Stack
@@ -135,16 +135,13 @@ const AdvancedTrackDetails = () => {
     >
       <SwitchInputField
         name="isInstrumental"
-        title="Is this song an instrumental?"
+        title="Is this track an instrumental?"
         tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.instrumental }
       />
       <SwitchInputField
         name="isExplicit"
-        title="Does the song contain explicit content?"
-        tooltipText={
-          "Explicit content includes strong or discriminatory language, " +
-          "or depictions of sex, violence or substance abuse."
-        }
+        title="Does the track contain explicit content?"
+        tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.explicit }
       />
       <CoverRemixSample />
       <Stack
@@ -153,110 +150,6 @@ const AdvancedTrackDetails = () => {
         gridTemplateColumns={ ["repeat(1, 1fr)", null, "repeat(2, 1fr)"] }
         rowGap={ [2, null, 3] }
       >
-        <TextInputField
-          disabled={ isDeclined }
-          isOptional={ false }
-          label="SCHEDULE RELEASE DATE"
-          min={ earliestReleaseDate ? earliestReleaseDate : minDistributionDate }
-          name="releaseDate"
-          placeholder="Select a day"
-          ref={ releaseDateRef }
-          tooltipText={
-            "When selecting a date to release your song on our " +
-            "platform, please remember to factor in approval from any " +
-            "contributors/featured artists as well as mint processing time " +
-            "which can take up to 15 days."
-          }
-          type="date"
-        />
-        <TextInputField
-          label="ORIGINAL PUBLICATION DATE"
-          max={ new Date().toISOString().split("T")[0] }
-          name="publicationDate"
-          placeholder="Select a day"
-          ref={ publicationDateRef }
-          tooltipText={
-            "If your song has already been launched on other platforms you " +
-            "may input the release date here, but it is not required."
-          }
-          type="date"
-        />
-        <CopyrightInputField
-          copyrightType="composition"
-          disabled={ isDeclined }
-          label="COMPOSITION COPYRIGHT"
-          ownerFieldName="compositionCopyrightOwner"
-          ref={ compositionCopyrightRef }
-          tooltipText={
-            <span>
-              The copyright for a musical composition covers the music and
-              lyrics of a song (not the recorded performance). It is typically
-              owned by the songwriter and/or music publisher. If you are not the
-              copyright holder of the track composition, please review{ " " }
-              <Link
-                href={ NEWM_STUDIO_COPYRIGHT_FAQ_URL }
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                copyright requirements
-              </Link>{ " " }
-              in our FAQ.
-            </span>
-          }
-          yearFieldName="compositionCopyrightYear"
-        />
-        <CopyrightInputField
-          copyrightType="phonographic"
-          disabled={ isDeclined }
-          label="SOUND RECORDING COPYRIGHT"
-          ownerFieldName="phonographicCopyrightOwner"
-          ref={ phonographicCopyrightRef }
-          tooltipText={
-            <span>
-              The copyright in a sound recording covers the recording itself (it
-              does not cover the music or lyrics of the track). It is typically
-              owned by the artist and/or record label. If you are not the
-              copyright holder of the sound recording, please review{ " " }
-              <Link
-                href={ NEWM_STUDIO_COPYRIGHT_FAQ_URL }
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                copyright requirements
-              </Link>{ " " }
-              in our FAQ.
-            </span>
-          }
-          yearFieldName="phonographicCopyrightYear"
-        />
-        <DropdownSelectField
-          disabled={ isDeclined }
-          label="RELEASE CODE TYPE"
-          name="barcodeType"
-          options={ [NONE_OPTION, "EAN", "UPC", "JAN"] }
-          placeholder="Select one"
-          tooltipText={
-            "If you already have a release code, select the code type here " +
-            "and enter the code in the next field. If not, leave this field " +
-            "blank and an EAN release code will be auto-generated for you."
-          }
-        />
-        <TextInputField
-          disabled={
-            values.barcodeType === NONE_OPTION ||
-            !values.barcodeType ||
-            isDeclined
-          }
-          label="RELEASE CODE NUMBER"
-          name="barcodeNumber"
-          placeholder="0000000000"
-          ref={ barcodeNumberRef }
-          tooltipText={
-            "A release code number is a unique code that identifies your " +
-            "release. If you do not already have one, leave this field blank, " +
-            "and an EAN release code number will be auto-generated for you."
-          }
-        />
         <TextInputField
           disabled={ isDeclined }
           label="ISRC"
@@ -274,19 +167,7 @@ const AdvancedTrackDetails = () => {
             setFieldValue("isrc", event.target.value.toUpperCase())
           }
         />
-        <TextInputField
-          label="IPI"
-          name="ipi"
-          placeholder="000000000"
-          ref={ ipiRef }
-          tooltipText={
-            "An IPI is a nine-digit number used to identify songwriters, " +
-            "composers, and music publishers; they are automatically assigned " +
-            "to rights holders through membership to a PRO. This information is " +
-            "optional; if you do not already have an IPI or choose not to obtain " +
-            "one, leave this field blank."
-          }
-        />
+
         <TextInputField
           label="ISWC"
           mask="T-999999999-9"
@@ -295,13 +176,68 @@ const AdvancedTrackDetails = () => {
           placeholder="T-000000000-0"
           ref={ iswcRef }
           tooltipText={
-            "An ISWC is the unique identification code of your song " +
+            "An ISWC is the unique identification code of your track " +
             "(unlike ISRC which is linked to  the specific recording). " +
             "This information is optional; if you do not already have an " +
             "ISWC or choose not to obtain one, whether this is an original " +
-            "song or a cover, leave this field blank."
+            "track or a cover, leave this field blank."
           }
         />
+
+        <CopyrightInputField
+          copyrightType="composition"
+          disabled={ isDeclined }
+          label="COMPOSITION COPYRIGHT"
+          ownerFieldName="compositionCopyrightOwner"
+          ref={ compositionCopyrightRef }
+          tooltipText={ FIELDS_TOOLTIP_COPY_NODE.compositionCopyright }
+          yearFieldName="compositionCopyrightYear"
+        />
+
+        <CopyrightInputField
+          copyrightType="phonographic"
+          disabled={ isDeclined }
+          label="SOUND RECORDING COPYRIGHT"
+          ownerFieldName="phonographicCopyrightOwner"
+          ref={ phonographicCopyrightRef }
+          tooltipText={ FIELDS_TOOLTIP_COPY_NODE.phonographicCopyright }
+          yearFieldName="phonographicCopyrightYear"
+        />
+      </Stack>
+
+      <HorizontalLine />
+
+      <Stack spacing={ 3 }>
+        <Box
+          ref={ coCreatorsRef }
+          sx={ {
+            backgroundColor: theme.colors.grey600,
+            border: `2px solid ${theme.colors.grey400}`,
+            borderRadius: "4px",
+          } }
+        >
+          <SelectCoCreators
+            creditors={ values.creditors }
+            featured={ values.featured }
+            isAddDeleteDisabled={ isDeclined }
+            owners={ values.owners }
+            onChangeCreditors={ handleChangeCreditors }
+            onChangeFeatured={ handleChangeFeatured }
+            onChangeOwners={ handleChangeOwners }
+          />
+        </Box>
+
+        { !!touched.owners && !!errors.owners && (
+          <Box mt={ 0.5 }>
+            <ErrorMessage>{ errors.owners as string }</ErrorMessage>
+          </Box>
+        ) }
+
+        { !!touched.creditors && !!errors.creditors && (
+          <Box mt={ 0.5 }>
+            <ErrorMessage>{ errors.creditors as string }</ErrorMessage>
+          </Box>
+        ) }
       </Stack>
     </Stack>
   );

--- a/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx
@@ -2,34 +2,31 @@ import { FunctionComponent, useEffect, useRef } from "react";
 
 import { useFormikContext } from "formik";
 
-import { Box, Link, Stack, Typography, useTheme } from "@mui/material";
+import { Link, Stack, Typography, useTheme } from "@mui/material";
 
 import {
   CheckboxField,
   DropdownMultiSelectField,
   DropdownSelectField,
-  ErrorMessage,
+  HorizontalLine,
   SolidOutline,
   TextAreaField,
   TextInputField,
-  UploadImageField,
   UploadSongField,
 } from "@newm-web/elements";
 import { scrollToError, useExtractProperty } from "@newm-web/utils";
 
 import { TrackFormValues } from "./trackFormTypes";
+import PlayTrack from "./tabs/PlayTrack";
 import {
   NEWM_STUDIO_FAQ_URL,
   SONG_DESCRIPTION_MAX_CHARACTER_COUNT,
 } from "../../../../../common";
-import { PlaySong } from "../../../../../components";
-import SelectCoCreators from "../../../../../components/minting/SelectCoCreators";
 import {
   useGetGenresQuery,
   useGetLanguagesQuery,
   useGetMoodsQuery,
 } from "../../../../../modules/content";
-import { Creditor, Featured, Owner } from "../../../../../modules/song";
 
 interface BasicTrackDetailsProps {
   readonly isDeclined?: boolean;
@@ -49,34 +46,15 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
   const languageOptions = useExtractProperty(languages, "language_name");
 
   const audioRef = useRef<HTMLDivElement>(null);
-  const coCreatorsRef = useRef<HTMLDivElement>(null);
   const coverArtUrlRef = useRef<HTMLDivElement>(null);
   const agreesToCoverArtGuidelinesRef = useRef<HTMLInputElement>(null);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
-  const songDetailsRef = useRef<HTMLDivElement>(null);
+  const trackDetailsRef = useRef<HTMLDivElement>(null);
 
-  const {
-    values,
-    errors,
-    touched,
-    setFieldValue,
-    isSubmitting,
-    initialValues,
-  } = useFormikContext<TrackFormValues>();
+  const { values, errors, setFieldValue, isSubmitting, initialValues } =
+    useFormikContext<TrackFormValues>();
 
   const hasCoverArtChanged = values.coverArtUrl !== initialValues.coverArtUrl;
-
-  const handleChangeOwners = (owners: ReadonlyArray<Owner>) => {
-    setFieldValue("owners", owners);
-  };
-
-  const handleChangeCreditors = (creditors: ReadonlyArray<Creditor>) => {
-    setFieldValue("creditors", creditors);
-  };
-
-  const handleChangeFeatured = (featured: ReadonlyArray<Featured>) => {
-    setFieldValue("featured", featured);
-  };
 
   useEffect(() => {
     scrollToError(errors, isSubmitting, [
@@ -87,15 +65,13 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
         error: errors.agreesToCoverArtGuidelines,
       },
       {
-        element: songDetailsRef.current,
+        element: trackDetailsRef.current,
         error: errors.title || errors.genres || errors.moods,
       },
       {
         element: descriptionRef.current,
         error: errors.description,
       },
-      { element: coCreatorsRef.current, error: errors.creditors },
-      { element: coCreatorsRef.current, error: errors.owners },
     ]);
   }, [errors, isSubmitting]);
 
@@ -128,7 +104,7 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
             { isInEditMode ? (
               <>
                 <Typography color={ theme.colors.grey100 } fontWeight={ 700 }>
-                  SONG
+                  TRACK
                 </Typography>
 
                 <SolidOutline
@@ -140,41 +116,48 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
                     justifyContent: "center",
                   } }
                 >
-                  <PlaySong id={ trackId } />
+                  <PlayTrack id={ trackId } />
                 </SolidOutline>
               </>
             ) : (
-              <>
-                <Typography color={ theme.colors.grey100 } fontWeight={ 700 }>
-                  SONG FILE
-                </Typography>
-
-                <UploadSongField name="audio" />
-              </>
+              <Stack
+                direction={ ["column", "column", "row"] }
+                spacing={ 1.5 }
+                sx={ {
+                  alignItems: ["stretch", "stretch", "flex-start"],
+                  gap: [2, null, 2],
+                  width: "100%",
+                } }
+              >
+                <Stack
+                  spacing={ 0.5 }
+                  sx={ {
+                    flex: ["1 1 auto", "1 1 auto", "0 0 320px"],
+                    maxWidth: ["100%", "100%", "320px"],
+                    minWidth: 0,
+                  } }
+                >
+                  <Typography color={ theme.colors.grey100 } fontWeight={ 700 }>
+                    TRACK FILE
+                  </Typography>
+                  <UploadSongField name="audio" />
+                </Stack>
+                <Stack
+                  spacing={ 0.5 }
+                  sx={ {
+                    flex: ["1 1 auto", "1 1 auto", "1 1 0"],
+                    minWidth: "100%",
+                  } }
+                >
+                  <TextInputField
+                    isOptional={ false }
+                    label="TRACK TITLE"
+                    name="title"
+                    placeholder="Give your track a name..."
+                  />
+                </Stack>
+              </Stack>
             ) }
-          </Stack>
-
-          <Stack
-            maxWidth={ theme.inputField.maxWidth }
-            ref={ coverArtUrlRef }
-            spacing={ 0.5 }
-            width="100%"
-          >
-            <Typography color={ theme.colors.grey100 } fontWeight={ 700 }>
-              SONG COVER ART
-            </Typography>
-
-            <UploadImageField
-              changeImageButtonText="Change cover"
-              emptyMessage="Drag and drop or browse your image"
-              maxFileSizeMB={ 10 }
-              minDimensions={ { height: 1400, width: 1400 } }
-              minFileSizeMB={ 0.1 }
-              name="coverArtUrl"
-              rootSx={ { alignSelf: "center", width: "100%" } }
-              hasPreviewOption
-              isAspectRatioOneToOne
-            />
           </Stack>
         </Stack>
 
@@ -220,7 +203,7 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
             />
           ) }
           <Stack
-            ref={ songDetailsRef }
+            ref={ trackDetailsRef }
             sx={ {
               columnGap: [undefined, undefined, 1.5],
               display: "grid",
@@ -228,19 +211,20 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
               rowGap: [2, null, 3],
             } }
           >
-            <TextInputField
+            <DropdownMultiSelectField
               isOptional={ false }
-              label="SONG TITLE"
-              name="title"
-              placeholder="Give your track a name..."
+              label="PRIMARY GENRE"
+              name="primaryGenre"
+              options={ genres ?? [] }
+              placeholder="Select primary genre"
             />
 
             <DropdownMultiSelectField
-              isOptional={ false }
-              label="GENRE"
-              name="genres"
-              options={ genres }
-              placeholder="Select all that apply"
+              isOptional={ true }
+              label="SECONDARY GENRE"
+              name="secondaryGenre"
+              options={ genres ?? [] }
+              placeholder="Select secondary genre"
             />
 
             <DropdownSelectField
@@ -267,37 +251,7 @@ const BasicTrackDetails: FunctionComponent<BasicTrackDetailsProps> = ({
             ref={ descriptionRef }
           />
 
-          <Stack spacing={ 3 }>
-            <Box
-              sx={ {
-                backgroundColor: theme.colors.grey600,
-                border: `2px solid ${theme.colors.grey400}`,
-                borderRadius: "4px",
-              } }
-            >
-              <SelectCoCreators
-                creditors={ values.creditors }
-                featured={ values.featured }
-                isAddDeleteDisabled={ isDeclined }
-                owners={ values.owners }
-                onChangeCreditors={ handleChangeCreditors }
-                onChangeFeatured={ handleChangeFeatured }
-                onChangeOwners={ handleChangeOwners }
-              />
-            </Box>
-
-            { !!touched.owners && !!errors.owners && (
-              <Box mt={ 0.5 }>
-                <ErrorMessage>{ errors.owners as string }</ErrorMessage>
-              </Box>
-            ) }
-
-            { !!touched.creditors && !!errors.creditors && (
-              <Box mt={ 0.5 }>
-                <ErrorMessage>{ errors.creditors as string }</ErrorMessage>
-              </Box>
-            ) }
-          </Stack>
+          <HorizontalLine />
         </Stack>
       </Stack>
     </Stack>

--- a/apps/studio/src/pages/home/releases/release/tracks/NewTrack.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/NewTrack.tsx
@@ -104,7 +104,6 @@ const NewTrack: FunctionComponent = () => {
       companyName = "",
       email,
       firstName = "",
-      ipi: userIpi,
       lastName = "",
       nickname: stageName = "",
       role,
@@ -145,8 +144,7 @@ const NewTrack: FunctionComponent = () => {
     ],
     description: "",
     featured: [],
-    genres: [],
-    ipi: userIpi,
+    genres: [], // TODO: Remove once fully migrated to Track type.
     isCoverRemixSample: false,
     isExplicit: false,
     isInstrumental: false,
@@ -166,8 +164,10 @@ const NewTrack: FunctionComponent = () => {
     paymentType: PaymentType.NEWM,
     phonographicCopyrightOwner: undefined,
     phonographicCopyrightYear: undefined,
-    publicationDate: undefined,
-    releaseDate: undefined,
+    primaryGenre: [],
+    publicationDate: undefined, // TODO: Remove once fully migrated to Track type.
+    releaseDate: undefined, // TODO: Remove once fully migrated to Track type.
+    secondaryGenre: [],
     stageName,
     title: "",
   };

--- a/apps/studio/src/pages/home/releases/release/tracks/ViewTrack.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/ViewTrack.tsx
@@ -111,6 +111,7 @@ const ViewTrack: FunctionComponent = () => {
 
         { title && <Typography variant="h3">{ title.toUpperCase() }</Typography> }
 
+        { /* // TODO: Replace with TrackDeletionHelp once API is updated. */ }
         <Tooltip title={ <ReleaseDeletionHelp /> }>
           <Stack ml="auto">
             <Button
@@ -128,7 +129,7 @@ const ViewTrack: FunctionComponent = () => {
 
       <Box pb={ 7 } pt={ 5 }>
         <Tabs
-          aria-label="Edit song details"
+          aria-label="Edit track details"
           sx={ {
             ".Mui-selected": {
               background: theme.gradients[colorMap[tab]],

--- a/apps/studio/src/pages/home/releases/release/tracks/tabs/PlayTrack.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/tabs/PlayTrack.tsx
@@ -1,0 +1,137 @@
+import { FunctionComponent, useEffect, useMemo, useState } from "react";
+
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import StopIcon from "@mui/icons-material/Stop";
+import { Stack, Typography } from "@mui/material";
+
+import { IconMessage } from "@newm-web/elements";
+import { PlayerState, Song } from "@newm-web/types";
+import { useHlsJs } from "@newm-web/utils";
+
+// TODO: Replace with useGetTrackQuery once API is updated.
+import {
+  useFetchSongStreamThunk,
+  useGetSongQuery,
+} from "../../../../../../modules/song";
+
+interface PlayTrackProps {
+  readonly id: string;
+}
+
+const PlayTrack: FunctionComponent<PlayTrackProps> = ({ id }) => {
+  const { data: song, isLoading } = useGetSongQuery(id);
+
+  const [playerState, setPlayerState] = useState<PlayerState>({
+    isReadyToPlay: false,
+  });
+
+  const [fetchStreamData, fetchStreamDataResp] = useFetchSongStreamThunk();
+
+  const hlsJsParams = useMemo(
+    () => ({
+      onPlaySong: ({ id }: Song) => {
+        setPlayerState((prevState) => ({
+          ...prevState,
+          currentPlayingSongId: id,
+          isReadyToPlay: false,
+        }));
+      },
+      onSongEnded: () => {
+        setPlayerState((prevState) => ({
+          ...prevState,
+          currentPlayingSongId: undefined,
+          isReadyToPlay: false,
+        }));
+      },
+      onStopSong: () => {
+        setPlayerState((prevState) => ({
+          ...prevState,
+          currentPlayingSongId: undefined,
+          isReadyToPlay: false,
+        }));
+      },
+    }),
+    []
+  );
+
+  const { playSong, stopSong } = useHlsJs(hlsJsParams);
+
+  /**
+   * Plays and/or stops the song depending on if it's currently playing or not.
+   */
+  const handleSongPlayPause = (song: Song) => {
+    const isSongPlaying = playerState.currentPlayingSongId;
+    const isNewSong = song.id !== playerState.currentPlayingSongId;
+
+    if (isSongPlaying) stopSong(song);
+    if (isNewSong) {
+      setPlayerState((prevState) => ({
+        ...prevState,
+        loadingSongId: song.id,
+      }));
+      fetchStreamData(song);
+    }
+  };
+
+  // handles the stream metadata response when loading a song
+  useEffect(() => {
+    if (fetchStreamDataResp.isLoading) {
+      return;
+    }
+
+    if (
+      fetchStreamDataResp.data &&
+      playerState.loadingSongId === fetchStreamDataResp.data.song.id
+    ) {
+      setPlayerState((prevState) => ({
+        ...prevState,
+        isReadyToPlay: true,
+        song: fetchStreamDataResp.data?.song,
+      }));
+    }
+  }, [
+    playerState.loadingSongId,
+    fetchStreamDataResp.isLoading,
+    fetchStreamDataResp.data,
+    playSong,
+  ]);
+
+  // when a songs stream information is ready - play the song
+  useEffect(() => {
+    if (playerState.isReadyToPlay && playerState.song) {
+      playSong(playerState.song);
+    }
+  }, [
+    playerState.song,
+    playerState.loadingSongId,
+    playerState.isReadyToPlay,
+    playSong,
+  ]);
+
+  // Keep song in a playing state till the song has been filtered out
+  useEffect(() => {
+    const isSongFound = song?.id === playerState.currentPlayingSongId;
+
+    if (!isSongFound) {
+      stopSong();
+    }
+  }, [playerState.currentPlayingSongId, song, stopSong]);
+
+  if (isLoading) return null;
+
+  return song?.streamUrl ? (
+    <Stack sx={ { cursor: "pointer", height: "100%", width: "100%" } }>
+      <IconMessage
+        icon={
+          playerState.currentPlayingSongId ? <StopIcon /> : <PlayArrowIcon />
+        }
+        message={ playerState.currentPlayingSongId ? "Stop track" : "Play track" }
+        onClick={ () => handleSongPlayPause(song) }
+      />
+    </Stack>
+  ) : (
+    <Typography>Unable to play track</Typography>
+  );
+};
+
+export default PlayTrack;

--- a/apps/studio/src/pages/home/releases/release/tracks/tabs/TrackInfo.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/tabs/TrackInfo.tsx
@@ -16,10 +16,15 @@ import {
 } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 
+import PlayTrack from "./PlayTrack";
 import { emptySong, useGetSongQuery } from "../../../../../../modules/song";
-import { CoverRemixSample, PlaySong } from "../../../../../../components";
+import { CoverRemixSample } from "../../../../../../components";
+import {
+  FIELDS_TOOLTIP_COPY_NODE,
+  FIELDS_TOOLTIP_COPY_TEXT,
+} from "../../../constants";
 
-const SongInfo = () => {
+const TrackInfo = () => {
   const windowWidth = useWindowDimensions()?.width;
   const { trackId } = useParams<"trackId">() as { trackId: string };
 
@@ -117,7 +122,7 @@ const SongInfo = () => {
                 width="100%"
               >
                 <Typography color={ theme.colors.grey100 } fontWeight={ 700 }>
-                  SONG
+                  TRACK
                 </Typography>
 
                 <SolidOutline
@@ -129,7 +134,7 @@ const SongInfo = () => {
                     justifyContent: "center",
                   } }
                 >
-                  <PlaySong id={ trackId || "" } />
+                  <PlayTrack id={ trackId || "" } />
                 </SolidOutline>
               </Stack>
 
@@ -139,7 +144,7 @@ const SongInfo = () => {
                 width="100%"
               >
                 <Typography color={ theme.colors.grey100 } fontWeight={ 700 }>
-                  SONG COVER ART
+                  TRACK COVER ART
                 </Typography>
 
                 <UploadImageField
@@ -179,7 +184,7 @@ const SongInfo = () => {
                 <TextInputField
                   disabled={ true }
                   isOptional={ false }
-                  label="SONG TITLE"
+                  label="TRACK TITLE"
                   name="title"
                   title={ values.title || "" }
                 />
@@ -187,7 +192,15 @@ const SongInfo = () => {
                 <TextInputField
                   disabled={ true }
                   isOptional={ false }
-                  label="GENRE"
+                  label="PRIMARY GENRE"
+                  name="genres"
+                  title={ values.genres?.join(", ") || "" }
+                />
+
+                <TextInputField
+                  disabled={ true }
+                  isOptional={ true }
+                  label="SECONDARY GENRE"
                   name="genres"
                   title={ values.genres?.join(", ") || "" }
                 />
@@ -232,21 +245,14 @@ const SongInfo = () => {
               <SwitchInputField
                 disabled={ true }
                 name="isInstrumental"
-                title="Is this song an instrumental?"
-                tooltipText={
-                  "Songs without voices or lyrics should be indicated as an " +
-                  "instrumental. Failure to accurately label the song will " +
-                  "result in a declined distribution submission."
-                }
+                title="Is this track an instrumental?"
+                tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.instrumental }
               />
               <SwitchInputField
                 disabled={ true }
                 name="isExplicit"
-                title="Does the song contain explicit content?"
-                tooltipText={
-                  "Explicit content includes strong or discriminatory language, " +
-                  "or depictions of sex, violence or substance abuse."
-                }
+                title="Does the track contain explicit content?"
+                tooltipText={ FIELDS_TOOLTIP_COPY_TEXT.explicit }
               />
               <CoverRemixSample disabled={ true } />
               <Stack
@@ -255,29 +261,6 @@ const SongInfo = () => {
                 gridTemplateColumns={ ["repeat(1, 1fr)", null, "repeat(2, 1fr)"] }
                 rowGap={ [2, null, 3] }
               >
-                <TextInputField
-                  disabled={ true }
-                  isOptional={ false }
-                  label="SCHEDULE RELEASE DATE"
-                  name="releaseDate"
-                  tooltipText={
-                    "When selecting a date to release your song on our " +
-                    "platform, please remember to factor in approval from any " +
-                    "contributors/featured artists as well as mint processing time " +
-                    "which can take up to 15 days."
-                  }
-                  type="date"
-                />
-                <TextInputField
-                  disabled={ true }
-                  label="ORIGINAL PUBLICATION DATE"
-                  name="publicationDate"
-                  tooltipText={
-                    "If your song has already been launched on other platforms you " +
-                    "may input the release date here, but it is not required."
-                  }
-                  type="date"
-                />
                 <CopyrightInputField
                   copyrightType="composition"
                   disabled={ true }
@@ -285,12 +268,7 @@ const SongInfo = () => {
                   label="COMPOSITION COPYRIGHT"
                   ownerFieldName="compositionCopyrightOwner"
                   placeholder=""
-                  tooltipText={
-                    "The copyright for a musical composition covers the " +
-                    "music and lyrics of a song (not the recorded " +
-                    "performance). It is typically owned by the songwriter " +
-                    "and/or music publisher."
-                  }
+                  tooltipText={ FIELDS_TOOLTIP_COPY_NODE.compositionCopyright }
                   yearFieldName="compositionCopyrightYear"
                 />
                 <CopyrightInputField
@@ -300,28 +278,10 @@ const SongInfo = () => {
                   label="SOUND RECORDING COPYRIGHT"
                   ownerFieldName="phonographicCopyrightOwner"
                   placeholder=""
-                  tooltipText={
-                    "The copyright in a sound recording covers the " +
-                    "recording itself (it does not cover the music " +
-                    "or lyrics of the song). It is typically owned by " +
-                    "the artist and/or record label."
-                  }
+                  tooltipText={ FIELDS_TOOLTIP_COPY_NODE.phonographicCopyright }
                   yearFieldName="phonographicCopyrightYear"
                 />
-                <TextInputField
-                  disabled={ true }
-                  label="RELEASE CODE TYPE"
-                  name="barcodeType"
-                />
-                <TextInputField
-                  disabled={ true }
-                  label="RELEASE CODE NUMBER"
-                  name="barcodeNumber"
-                  tooltipText={
-                    "A release code number is a unique code that identifies " +
-                    "your release."
-                  }
-                />
+
                 <TextInputField
                   disabled={ true }
                   label="ISRC"
@@ -333,16 +293,7 @@ const SongInfo = () => {
                     "recording."
                   }
                 />
-                <TextInputField
-                  disabled={ true }
-                  label="IPI"
-                  name="ipi"
-                  tooltipText={
-                    "An IPI is a nine-digit number used to identify songwriters, " +
-                    "composers, and music publishers."
-                  }
-                  type="number"
-                />
+
                 <TextInputField
                   disabled={ true }
                   label="ISWC"
@@ -363,4 +314,4 @@ const SongInfo = () => {
   );
 };
 
-export default SongInfo;
+export default TrackInfo;

--- a/apps/studio/src/pages/home/releases/release/tracks/trackFormTypes.ts
+++ b/apps/studio/src/pages/home/releases/release/tracks/trackFormTypes.ts
@@ -2,4 +2,6 @@ import { UploadSongThunkRequest } from "../../../../../modules/song";
 
 export interface TrackFormValues extends UploadSongThunkRequest {
   agreesToCoverArtGuidelines?: boolean;
+  primaryGenre?: string[];
+  secondaryGenre?: string[];
 }


### PR DESCRIPTION
# Pull Request — Issue #[TBD](https://projectnewm.atlassian.net/browse/TBD)

## Overview

Update Studio releases/track flow for phase 2: add release type selection, refine
track UI/copy, centralize tooltip copy, introduce release/track types, and add a
README with pending work and cleanup notes.

---

## Files Summary

**Total Changes:** 18 files

<details>
<summary>Added (8)</summary>

- **`apps/studio/src/modules/releases/index.ts`**
  - Barrel export for release/track modules.
- **`apps/studio/src/modules/releases/release/index.ts`**
  - Release module exports.
- **`apps/studio/src/modules/releases/release/types.ts`**
  - Tentative release type definition.
- **`apps/studio/src/modules/releases/track/index.ts`**
  - Track module exports.
- **`apps/studio/src/modules/releases/track/types.ts`**
  - Tentative track type definition.
- **`apps/studio/src/pages/home/releases/README.md`**
  - Phase 2 release/track workflow notes and cleanup checklist.
- **`apps/studio/src/pages/home/releases/constants.tsx`**
  - Shared tooltip copy for release/track fields.
- **`apps/studio/src/pages/home/releases/release/tracks/tabs/PlayTrack.tsx`**
  - Track playback component used in the track info tab.

</details>

<details>
<summary>Modified (10)</summary>

- **`apps/studio/src/common/constants.ts`**
  - Marked tooltip copy as legacy/compatibility.
- **`apps/studio/src/components/minting/CoverRemixSample.tsx`**
  - Updated copy to reference tracks.
- **`apps/studio/src/pages/home/releases/ReleaseList.tsx`**
  - Swapped inline Release type for shared module type.
- **`apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx`**
  - Added release type dropdown; simplified header UI.
- **`apps/studio/src/pages/home/releases/release/tracks/AdvancedTrackDetails.tsx`**
  - Reworked advanced track fields and tooltip copy; cleanup for phase 2.
- **`apps/studio/src/pages/home/releases/release/tracks/BasicTrackDetails.tsx`**
  - Updated track details form structure and labels.
- **`apps/studio/src/pages/home/releases/release/tracks/NewTrack.tsx`**
  - Aligned track creation flow with updated forms.
- **`apps/studio/src/pages/home/releases/release/tracks/ViewTrack.tsx`**
  - Updated tab copy and TODO note for delete behavior.
- **`apps/studio/src/pages/home/releases/release/tracks/tabs/TrackInfo.tsx`**
  - Renamed component, updated labels, and added play track integration.
- **`apps/studio/src/pages/home/releases/release/tracks/trackFormTypes.ts`**
  - Added primary/secondary genre fields.

</details>

<details>
<summary>Deleted (0)</summary>

- None.

</details>

---

## Impact

- Updates release/track UI copy and form structure for phase 2 workflows.
- Introduces tentative release/track types and shared tooltip constants.
- Adds a play-track tab component and a README outlining pending backend work.

---

## Testing

- Not run (local changes only).

---

## Related Issues

- References: [TBD](https://projectnewm.atlassian.net/browse/TBD)

---

## Dependencies

- No new dependencies.

---

## Additional Notes

- Backend model/type alignment and cleanup tasks are tracked in
  `apps/studio/src/pages/home/releases/README.md`.

--END--
